### PR TITLE
Feature/wiki one page

### DIFF
--- a/website/addons/wiki/templates/edit.mako
+++ b/website/addons/wiki/templates/edit.mako
@@ -1,6 +1,15 @@
 <%page expression_filter="h"/>
 <%inherit file="project/project_base.mako"/>
 <%def name="title()">${node['title'] | n} Wiki</%def>
+<style>
+@media (min-width: 1601px) {
+  .container {
+      width : 100%;
+      padding-left: 20px;
+      paddong-right: 20px;
+  }
+}
+</style>
 
 <div class="row">
     <div class="col-xs-6">

--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -1964,11 +1964,9 @@ span#profileFullname{
         overflow: hidden;
     }
     .osf-search {
-        margin-top: -8px;
         z-index: 1028;
     }
     #searchControls > .osf-search {
-        margin-top: -8px;
         z-index: 99;
     }
     .osf-xs-search {
@@ -1983,7 +1981,7 @@ span#profileFullname{
         padding-right: 7px;
     }
     .navbar .search-query {
-    width: 190px;
+        width: 190px;
     }
     .osf-project-navbar a.project-title {
         max-width: 190px;
@@ -1993,13 +1991,8 @@ span#profileFullname{
         padding-left: 0;
     }
     .osf-search {
-        margin-top: -30px;
         z-index: 1028; /* should be less than 1030 to not cover navbar */
     }
-    #searchControls > .osf-search {
-        margin-top: -8px;
-    }
-
 }
 
 @media (min-width: 992px) {
@@ -2020,7 +2013,7 @@ span#profileFullname{
         padding-right: 15px;
     }
     .navbar .search-query {
-    width: 270px;
+        width: 270px;
     }
     .osf-project-navbar a.project-title {
         max-width: 400px;
@@ -2035,10 +2028,9 @@ span#profileFullname{
     width: 100%;
     box-shadow: 0 0 9px -2px #464545;
     left: 0;
+    top: 43px;
 }
-#searchControls > .osf-search {
-    margin-top: -8px;
-}
+
 .osf-search-input {
     background: none;
     border: none;

--- a/website/static/js/pages/wiki-edit-page.js
+++ b/website/static/js/pages/wiki-edit-page.js
@@ -102,12 +102,7 @@ $(document).ready(function () {
 
         }
     });
-    $('.openNewWiki').click(function () {
-        $('#newWiki').modal('show');
-    });
-    $('.openDeleteWiki').click(function () {
-        $('#deleteWiki').modal('show');
-    });
+
     var panelToggle = $('.panel-toggle'),
         panelExpand = $('.panel-expand');
     $('.panel-collapse').on('click', function () {

--- a/website/static/js/pages/wiki-edit-page.js
+++ b/website/static/js/pages/wiki-edit-page.js
@@ -103,8 +103,8 @@ $(document).ready(function () {
         }
     });
 
-    var panelToggle = $('.panel-toggle'),
-        panelExpand = $('.panel-expand');
+    var panelToggle = $('.panel-toggle');
+    var panelExpand = $('.panel-expand');
     $('.panel-collapse').on('click', function () {
         var el = $(this).closest('.panel-toggle');
         el.children('.wiki-panel.hidden-xs').hide();
@@ -114,8 +114,8 @@ $(document).ready(function () {
         $('.wiki-nav').show();
     });
     $('.panel-collapsed .wiki-panel-header').on('click', function () {
-        var el = $(this).parent(),
-            toggle = el.closest('.panel-toggle');
+        var el = $(this).parent();
+        var toggle = el.closest('.panel-toggle');
         toggle.children('.wiki-panel').show();
         el.hide();
         panelToggle.removeClass('col-sm-1').addClass('col-sm-3');


### PR DESCRIPTION
## Purpose
Add XXL sizing only to wiki and fix search bar issues

## Changes
- Added page head style for container size to become 100% when page width is more than 1600px
- Revised the Search bar CSS to more properly position and avoid errors.
- Removed modal calls in wiki edit page js that were in the mako fiel already
- fixed one var statement per line from code review 

## Side effects
I tested the search bar in several scenarios, all seemed to work fine. The container change is limited to the wiki page only but there might be a better way to handle it. Ideally wiki CSS should be not part of Site.css or each page body should have their own classes. 