### PR TITLE
Fix onload visibility and continuity across window sizes

### DIFF
--- a/website/addons/wiki/templates/edit.mako
+++ b/website/addons/wiki/templates/edit.mako
@@ -6,16 +6,16 @@
   .container {
       width : 100%;
       padding-left: 20px;
-      paddong-right: 20px;
+      padding-right: 20px;
   }
 }
 </style>
 
-<div class="row">
-    <div class="col-xs-6">
+<div class="row" style="margin-bottom: 5px;">
+    <div class="col-sm-6">
         <%include file="wiki/templates/status.mako"/>
     </div>
-    <div class="col-xs-6">
+    <div class="col-sm-6">
         <div class="pull-right">
           <div class="switch"></div>
           </div>

--- a/website/static/js/pages/wiki-edit-page.js
+++ b/website/static/js/pages/wiki-edit-page.js
@@ -86,7 +86,7 @@ if (ctx.canEditPageName) {
 $(document).ready(function () {
     $('*[data-osf-panel]').osfPanel({
         buttonElement : '.switch',
-        onSize : 'md',
+        onSize : 'xs',
         'onclick' : function (title, thisbtn, event ) {
             // this = all the column elements; an array
             // title = Text of the button


### PR DESCRIPTION
## Purpose 

This PR  makes sure the specific visibility set on load is properly maintained by the plugin and wiki page on different window sizes

## Changes
- The major change is in the plugin, so you need to run "bower update osf-panel"
- The window size where the plugin comes into effect is changed to xs to apply to all sizes
- Minor view changes. 

## Side effects
In XS mode the columns are stacked on top of each other so users may miss that they are still open but it's better to keep the toggle buttons visible all the time. Should not affect anything else, wiki is the only page using the toggling so far. 