### PR TITLE
Fix full height of edit with addition of wiki-panel-footer

### DIFF
--- a/website/addons/wiki/templates/edit.mako
+++ b/website/addons/wiki/templates/edit.mako
@@ -80,8 +80,8 @@
                         </div>
                     </div>
                   </div>
+                  <form id="wiki-form" action="${urls['web']['edit']}" method="POST">
                   <div class="wiki-panel-body">
-                      <form id="wiki-form" action="${urls['web']['edit']}" method="POST">
                         <div class="row">
                         <div class="col-xs-12">
                           <div class="form-group wmd-panel">
@@ -99,7 +99,9 @@
                                    data-bind="ace: currentText">Loading. . .</div>
                           </div>
                         </div>
-                      </div>
+                      </div>                    
+                  </div>
+                  <div class="wiki-panel-footer">
                       <div class="row">
                         <div class="col-xs-12">
                            <div class="pull-right">
@@ -117,8 +119,8 @@
                         <!-- Invisible textarea for form submission -->
                         <textarea name="content" style="display: none;"
                                   data-bind="value: currentText"></textarea>
-                    </form>
                   </div>
+                </form>
                 </div>
             </div>
           % endif

--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -389,7 +389,7 @@ li.pointer {
 /* Style for Ace wiki editor */
 .wiki-editor {
     position: relative;
-    height: 530px;
+    height: 590px;
     border: solid;
     border-width: 1px;
 }
@@ -1144,8 +1144,8 @@ div.search-result  {
 .wmd-button-row
 {
     position: relative;
-    margin-left: 5px;
-    margin-right: 5px;
+    margin-left: 0;
+    margin-right: 0;
     margin-bottom: 5px;
     margin-top: 0px;
     padding: 0px;
@@ -2138,6 +2138,7 @@ span#profileFullname{
     overflow: auto;
     display: block;
     position: relative;
+    overflow-x: hidden;
 }
 .superlist li.active {
     background: #EFEFEF;

--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -389,7 +389,7 @@ li.pointer {
 /* Style for Ace wiki editor */
 .wiki-editor {
     position: relative;
-    height: 450px;
+    height: 530px;
     border: solid;
     border-width: 1px;
 }
@@ -2130,13 +2130,16 @@ span#profileFullname{
 /* Wiki additions */
 .wiki-panel {
     border: 1px solid #ccc;
+    height: 750px;
+    overflow: auto;
+    display: block;
+    position: relative;
 }
 .superlist li.active {
     background: #EFEFEF;
     font-weight: bold;
 }
 .wiki-panel-body {
-    height: 700px;
     overflow: auto;
     overflow-x: hidden;
 }
@@ -2151,6 +2154,15 @@ span#profileFullname{
     font-weight: 300;
 }
 
+.wiki-panel-footer {
+    position: absolute;
+    bottom : 0;
+    left: 0;
+    padding: 10px;
+    background: #F5F5F5;
+    width: 100%;
+    z-index: 99;
+}
 #wiki-form {
     padding: 10px;
 }


### PR DESCRIPTION
## Purpose
Makes the edit fill the entire height, taking into account potential height changes in the body

## Changes
- Add a wiki-panel-footer div and required classes to make it stick to bottom
- Fixes for related heights and layouts (i.e. add fixed height to panel instead of body) 

## Side effects
Shouldn't be any, checked in Chrome, Safari, Firefox.  