### PR TITLE
Feature: API V2 DRF configure caching & rate-limiting

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -3,12 +3,16 @@
 
 ## Getting started
 
+Install memcached:
+```$ brew install memcached```
+
 From the root osf directory:
 
 ```bash
 pip install -r requirements.txt
 # Required for browse-able API
 python manage.py collectstatic
+invoke memcached
 invoke server
 ```
 

--- a/api/base/settings.py
+++ b/api/base/settings.py
@@ -61,6 +61,7 @@ REST_FRAMEWORK = {
         'api.base.authentication.drf.OSFBasicAuthentication',
         'api.base.authentication.drf.OSFSessionAuthentication',
     ),
+    # Must have memcached running
     'DEFAULT_THROTTLE_CLASSES': (
     'rest_framework.throttling.AnonRateThrottle',
     'rest_framework.throttling.UserRateThrottle'
@@ -68,6 +69,13 @@ REST_FRAMEWORK = {
     'DEFAULT_THROTTLE_RATES': {
         'anon': '100/day',
         'user': '1000/day'
+    }
+}
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+        'LOCATION': '127.0.0.1:11211',
     }
 }
 

--- a/api/base/settings.py
+++ b/api/base/settings.py
@@ -61,6 +61,14 @@ REST_FRAMEWORK = {
         'api.base.authentication.drf.OSFBasicAuthentication',
         'api.base.authentication.drf.OSFSessionAuthentication',
     ),
+    'DEFAULT_THROTTLE_CLASSES': (
+    'rest_framework.throttling.AnonRateThrottle',
+    'rest_framework.throttling.UserRateThrottle'
+    ),
+    'DEFAULT_THROTTLE_RATES': {
+        'anon': '100/day',
+        'user': '1000/day'
+    }
 }
 
 MIDDLEWARE_CLASSES = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ py-bcrypt==0.4
 pymongo==2.5.1
 python-dateutil==2.4.2
 python-gnupg==0.3.6
+python-memcached==1.54
 pytz==2014.9
 bleach==1.4.1
 html5lib==0.999

--- a/tasks.py
+++ b/tasks.py
@@ -287,6 +287,9 @@ def celery_worker(level="debug"):
     cmd = 'celery worker -A framework.tasks -l {0}'.format(level)
     run(bin_prefix(cmd))
 
+@task
+def memcached(echo=True):
+    run('memcached -d', echo=True)
 
 @task
 def rabbitmq():


### PR DESCRIPTION
Purpose:
-----------
Closes #22 and #23 

Changes: 
------------
- Configured default rate limits (these are just numbers taken from the DRF example http://www.django-rest-framework.org/api-guide/throttling/): 
  - 100/day for non-logged-in users
  - 1000/day for logged-in users
- Configured memcached as the caching backend