### PR TITLE
Feature: API V2 DRF filter node contributors

### DIFF
--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -32,7 +32,41 @@ def intersect(x, y):
     return x & y
 
 
-class ODMFilterMixin(object):
+class FilterMixin(object):
+    """ View mixin with helper functions for filtering. """
+
+    TRUTHY = set(['true', 'True', 1, '1'])
+    FALSY = set(['false', 'False', 0, '0'])
+    DEFAULT_OPERATOR = 'eq'
+
+    def is_filterable_field(self, key):
+        try:
+            return key.strip() in self.serializer_class.filterable_fields
+        except AttributeError:
+            return key.strip() in self.serializer_class._declared_fields
+
+    # Used so that that queries by _id will work
+    def convert_key(self, key):
+        key = key.strip()
+        if self.serializer_class._declared_fields[key].source:
+            return self.serializer_class._declared_fields[key].source
+        return key
+
+    # Used to convert string values from query params to Python booleans when necessary
+    def convert_value(self, value):
+        value = value.strip()
+        if value in self.TRUTHY:
+            return True
+        elif value in self.FALSY:
+            return False
+        # Convert me to current user's pk
+        elif value == 'me' and not self.request.user.is_anonymous():
+            return self.request.user.pk
+        else:
+            return value
+
+
+class ODMFilterMixin(FilterMixin):
     """View mixin that adds a get_query_from_request method which converts query params
     of the form `filter[field_name]=value` into an ODM Query object.
 
@@ -43,10 +77,6 @@ class ODMFilterMixin(object):
     """
 
     # TODO Handle simple and complex non-standard fields
-
-    TRUTHY = set(['true', 'True', 1, '1'])
-    FALSY = set(['false', 'False', 0, '0'])
-    DEFAULT_OPERATOR = 'eq'
 
     # For the field_comparison_operators, instances can be a class or a tuple of classes
     field_comparison_operators = [
@@ -67,12 +97,6 @@ class ODMFilterMixin(object):
                 return operator['comparison_operator']
 
         return self.DEFAULT_OPERATOR
-
-    def is_filterable_field(self, key):
-        try:
-            return key.strip() in self.serializer_class.filterable_fields
-        except AttributeError:
-            return key.strip() in self.serializer_class._declared_fields
 
     def get_default_odm_query(self):
         raise NotImplementedError('Must define get_default_odm_query')
@@ -106,28 +130,8 @@ class ODMFilterMixin(object):
             query = None
         return query
 
-    # Used so that that queries by _id will work
-    def convert_key(self, key):
-        key = key.strip()
-        if self.serializer_class._declared_fields[key].source:
-            return self.serializer_class._declared_fields[key].source
-        return key
 
-    # Used to convert string values from query params to Python booleans when necessary
-    def convert_value(self, value):
-        value = value.strip()
-        if value in self.TRUTHY:
-            return True
-        elif value in self.FALSY:
-            return False
-        # Convert me to current user's pk
-        elif value == 'me' and not self.request.user.is_anonymous():
-            return self.request.user.pk
-        else:
-            return value
-
-
-class SerializerFilterMixin(object):
+class SerializerFilterMixin(FilterMixin):
     """View mixin that adds a get_queryset_from_request method which uses query params
     of the form `filter[field_name]=value` to filter a list of objects.
 
@@ -136,16 +140,6 @@ class SerializerFilterMixin(object):
     Serializers that want to restrict which fields are used for filtering need to have a variable called
     filterable_fields which is a frozenset of strings representing the field names as they appear in the serialization.
     """
-
-    TRUTHY = set(['true', 'True', 1, '1'])
-    FALSY = set(['false', 'False', 0, '0'])
-    DEFAULT_OPERATOR = 'eq'
-
-    def is_filterable_field(self, key):
-        try:
-            return key.strip() in self.serializer_class.filterable_fields
-        except AttributeError:
-            return key.strip() in self.serializer_class._declared_fields
 
     def get_default_queryset(self):
         raise NotImplementedError('Must define get_default_queryset')
@@ -175,23 +169,3 @@ class SerializerFilterMixin(object):
             'bibliographic': serializer.get_bibliographic
         }
         return [item for item in default_queryset if serializer_function[key](item) == self.convert_value(value)]
-
-    # Used so that that queries by _id will work
-    def convert_key(self, key):
-        key = key.strip()
-        if self.serializer_class._declared_fields[key].source:
-            return self.serializer_class._declared_fields[key].source
-        return key
-
-    # Used to convert string values from query params to Python booleans when necessary
-    def convert_value(self, value):
-        value = value.strip()
-        if value in self.TRUTHY:
-            return True
-        elif value in self.FALSY:
-            return False
-        # Convert me to current user's pk
-        elif value == 'me' and not self.request.user.is_anonymous():
-            return self.request.user.pk
-        else:
-            return value

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -131,7 +131,7 @@ class ODMFilterMixin(FilterMixin):
         return query
 
 
-class SerializerFilterMixin(FilterMixin):
+class ListFilterMixin(FilterMixin):
     """View mixin that adds a get_queryset_from_request method which uses query params
     of the form `filter[field_name]=value` to filter a list of objects.
 

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -125,3 +125,73 @@ class ODMFilterMixin(object):
             return self.request.user.pk
         else:
             return value
+
+
+class SerializerFilterMixin(object):
+    """View mixin that adds a get_queryset_from_request method which uses query params
+    of the form `filter[field_name]=value` to filter a list of objects.
+
+    Subclasses must define `get_default_queryset()`.
+
+    Serializers that want to restrict which fields are used for filtering need to have a variable called
+    filterable_fields which is a frozenset of strings representing the field names as they appear in the serialization.
+    """
+
+    TRUTHY = set(['true', 'True', 1, '1'])
+    FALSY = set(['false', 'False', 0, '0'])
+    DEFAULT_OPERATOR = 'eq'
+
+    def is_filterable_field(self, key):
+        try:
+            return key.strip() in self.serializer_class.filterable_fields
+        except AttributeError:
+            return key.strip() in self.serializer_class._declared_fields
+
+    def get_default_queryset(self):
+        raise NotImplementedError('Must define get_default_queryset')
+
+    def get_queryset_from_request(self):
+        default_queryset = self.get_default_queryset()
+        param_queryset = self.param_queryset(self.request.QUERY_PARAMS, default_queryset)
+        return param_queryset or default_queryset
+
+    def param_queryset(self, query_params, default_queryset):
+        """filters default queryset based on query parameters"""
+        fields_dict = query_params_to_fields(query_params)
+        if fields_dict:
+            for k in fields_dict:
+                v = fields_dict[k]
+                if self.is_filterable_field(key=k):
+                    if isinstance(self.serializer_class._declared_fields[k], ser.SerializerMethodField):
+                        return self.get_serializer_field_value(k, v, default_queryset)
+                    elif isinstance(self.serializer_class._declared_fields[k], ser.BooleanField):
+                        return [item for item in default_queryset if item.get('key', None) == v]
+                    else:
+                        return [item for item in default_queryset if v in item.get('key', None)]
+
+    def get_serializer_field_value(self, key, value, default_queryset):
+        serializer = self.get_serializer()
+        serializer_function = {
+            'bibliographic': serializer.get_bibliographic
+        }
+        return [item for item in default_queryset if serializer_function[key](item) == self.convert_value(value)]
+
+    # Used so that that queries by _id will work
+    def convert_key(self, key):
+        key = key.strip()
+        if self.serializer_class._declared_fields[key].source:
+            return self.serializer_class._declared_fields[key].source
+        return key
+
+    # Used to convert string values from query params to Python booleans when necessary
+    def convert_value(self, value):
+        value = value.strip()
+        if value in self.TRUTHY:
+            return True
+        elif value in self.FALSY:
+            return False
+        # Convert me to current user's pk
+        elif value == 'me' and not self.request.user.is_anonymous():
+            return self.request.user.pk
+        else:
+            return value

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -6,9 +6,9 @@ from modularodm import Q
 from framework.auth.core import Auth
 from website.models import Node, Pointer
 from api.base.utils import get_object_or_404, waterbutler_url_for
-from api.base.filters import ODMFilterMixin
+from api.base.filters import ODMFilterMixin, SerializerFilterMixin
 from .serializers import NodeSerializer, NodePointersSerializer, NodeFilesSerializer
-from api.users.serializers import UserSerializer, ContributorSerializer
+from api.users.serializers import ContributorSerializer
 from .permissions import ContributorOrPublic, ReadOnlyIfRegistration
 
 
@@ -81,7 +81,7 @@ class NodeDetail(generics.RetrieveUpdateAPIView, NodeMixin):
         return {'request': self.request}
 
 
-class NodeContributorsList(generics.ListAPIView, NodeMixin):
+class NodeContributorsList(generics.ListAPIView, SerializerFilterMixin, NodeMixin):
     """Return the contributors (users) for a node."""
 
     permission_classes = (
@@ -90,9 +90,13 @@ class NodeContributorsList(generics.ListAPIView, NodeMixin):
 
     serializer_class = ContributorSerializer
 
+    def get_default_queryset(self):
+        node = self.get_node()
+        return node.contributors
+
     # overrides ListAPIView
     def get_queryset(self):
-        return self.get_node().contributors
+        return self.get_queryset_from_request()
 
 
 class NodeRegistrationsList(generics.ListAPIView, NodeMixin):

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -8,7 +8,7 @@ from website.models import Node, Pointer
 from api.base.utils import get_object_or_404, waterbutler_url_for
 from api.base.filters import ODMFilterMixin
 from .serializers import NodeSerializer, NodePointersSerializer, NodeFilesSerializer
-from api.users.serializers import UserSerializer
+from api.users.serializers import UserSerializer, ContributorSerializer
 from .permissions import ContributorOrPublic, ReadOnlyIfRegistration
 
 
@@ -82,13 +82,13 @@ class NodeDetail(generics.RetrieveUpdateAPIView, NodeMixin):
 
 
 class NodeContributorsList(generics.ListAPIView, NodeMixin):
-    """Return the contributors (users) fora node."""
+    """Return the contributors (users) for a node."""
 
     permission_classes = (
         ContributorOrPublic,
     )
 
-    serializer_class = UserSerializer
+    serializer_class = ContributorSerializer
 
     # overrides ListAPIView
     def get_queryset(self):

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -92,7 +92,7 @@ class NodeContributorsList(generics.ListAPIView, NodeMixin):
 
     # overrides ListAPIView
     def get_queryset(self):
-        return self.get_node().visible_contributors
+        return self.get_node().contributors
 
 
 class NodeRegistrationsList(generics.ListAPIView, NodeMixin):

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -6,7 +6,7 @@ from modularodm import Q
 from framework.auth.core import Auth
 from website.models import Node, Pointer
 from api.base.utils import get_object_or_404, waterbutler_url_for
-from api.base.filters import ODMFilterMixin, SerializerFilterMixin
+from api.base.filters import ODMFilterMixin, ListFilterMixin
 from .serializers import NodeSerializer, NodePointersSerializer, NodeFilesSerializer
 from api.users.serializers import ContributorSerializer
 from .permissions import ContributorOrPublic, ReadOnlyIfRegistration
@@ -81,7 +81,7 @@ class NodeDetail(generics.RetrieveUpdateAPIView, NodeMixin):
         return {'request': self.request}
 
 
-class NodeContributorsList(generics.ListAPIView, SerializerFilterMixin, NodeMixin):
+class NodeContributorsList(generics.ListAPIView, ListFilterMixin, NodeMixin):
     """Return the contributors (users) for a node."""
 
     permission_classes = (

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -36,10 +36,11 @@ class UserSerializer(JSONAPISerializer):
 
 
 class ContributorSerializer(UserSerializer):
-    is_bibliographic = ser.SerializerMethodField()
 
-    def get_is_bibliographic(self, obj):
+    filterable_fields = frozenset(['bibliographic'])
+
+    bibliographic = ser.SerializerMethodField()
+
+    def get_bibliographic(self, obj):
         node = self.context['view'].get_node()
         return obj._id in node.visible_contributor_ids
-
-    # TODO: Add filtering

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -33,3 +33,13 @@ class UserSerializer(JSONAPISerializer):
     def update(self, instance, validated_data):
         # TODO
         pass
+
+
+class ContributorSerializer(UserSerializer):
+    is_bibliographic = ser.SerializerMethodField()
+
+    def get_is_bibliographic(self, obj):
+        node = self.context['view'].get_node()
+        return obj._id in node.visible_contributor_ids
+
+    # TODO: Add filtering


### PR DESCRIPTION
- Added `ContributorSerializer` class that is a subclass of `UserSerializer` with a serializer method field `bibliographic`, which gets whether the user being serialized is a bibliographic contributor on the node.
- Added a `ListFilterMixin` and use it to filter the node contributors list based on bibliographic/nonbibliographic contributor status. In order to do this, the contributors endpoint was changed to return all contributors, not just bibliographic contributors.
- Combine duplicate mixin logic into a `FilterMixin`