### PR TITLE
Build absolute urls with current domain

### DIFF
--- a/api/base/utils.py
+++ b/api/base/utils.py
@@ -15,7 +15,8 @@ def absolute_reverse(view_name, query_kwargs=None, args=None, kwargs=None):
     if query_kwargs:
         relative_url = u'%s?%s' % (relative_url, urlencode(query_kwargs))
 
-    return urlparse.urljoin(settings.API_DOMAIN, relative_url)
+    domain = settings.DOMAIN if settings.API_SERVER_PORT == 5000 else settings.API_DOMAIN
+    return urlparse.urljoin(domain, relative_url)
 
 
 def get_object_or_404(model_cls, query_or_pk):

--- a/tasks.py
+++ b/tasks.py
@@ -45,6 +45,7 @@ def server(host=None, port=5000, debug=True, live=False):
     """Run the app server."""
     from website.app import init_app
     app = init_app(set_backends=True, routes=True, mfr=True)
+    settings.API_SERVER_PORT = port
 
     if live:
         from livereload import Server

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -41,6 +41,7 @@ ANALYTICS_PATH = os.path.join(BASE_PATH, 'analytics')
 CORE_TEMPLATES = os.path.join(BASE_PATH, 'templates/log_templates.mako')
 BUILT_TEMPLATES = os.path.join(BASE_PATH, 'templates/_log_templates.mako')
 
+API_SERVER_PORT = 8000
 DOMAIN = 'http://localhost:5000/'
 API_DOMAIN = 'http://localhost:8000/'
 OFFLOAD_DOMAIN = 'http://localhost:5001/'


### PR DESCRIPTION
Addresses the first half of #28: 

>If we're going to have the ability to run via the OSF and via a Django App, we'll need to ensure that everything works in both places. Currently, the Links class is returning port 8000 for all links regardless of if it's running on 5000 or 8000. 

@brianjgeiger, @sloria what do you think of this solution? 