### PR TITLE
Fix cos logo icon for api v2 swagger ui 

### DIFF
--- a/api/templates/rest_framework_swagger/base.html
+++ b/api/templates/rest_framework_swagger/base.html
@@ -9,8 +9,8 @@
             <link href="//fonts.googleapis.com/css?family=Droid+Sans:400,700" rel="stylesheet" type="text/css"/>
             <link href="{% static 'rest_framework_swagger/css/highlight.default.css' %}" media="screen" rel="stylesheet" type="text/css"/>
             <link href="{% static 'rest_framework_swagger/css/atelier-dune.light.css' %}" media="screen" rel="stylesheet" type="text/css"/>
-            <link href="{% static 'rest_framework_swagger/css/osf_rest_framework_swagger.css' %}" media="screen" rel="stylesheet" type="text/css"/>
-            <link href="{% static 'rest_framework_swagger/css/osf_screen.css' %}" media="screen" rel="stylesheet" type="text/css"/>
+            <link href="{% static 'rest_framework_swagger/css/rest_framework_swagger.css' %}" media="screen" rel="stylesheet" type="text/css"/>
+            <link href="{% static 'rest_framework_swagger/css/screen.css' %}" media="screen" rel="stylesheet" type="text/css"/>
         {% endblock %}
     </head>
 

--- a/api/templates/rest_framework_swagger/index.html
+++ b/api/templates/rest_framework_swagger/index.html
@@ -1,9 +1,11 @@
 {% extends 'rest_framework_swagger/base.html' %}
+{% load staticfiles %}
 
 {% block branding %}
     <a id="logo" href="http://osf.io">
-        <img class="osf-logo" src="/static/rest_framework_swagger/images/cos-white2.png" width="27">
-        OSF</a>
+        <img class="osf-logo" src="{% static 'rest_framework_swagger/images/cos-white2.png' %}" width="27">
+        OSF
+    </a>
 {% endblock %}
 {% block api_selector %}
     <form id="api_selector">

--- a/api/templates/rest_framework_swagger/index.html
+++ b/api/templates/rest_framework_swagger/index.html
@@ -1,6 +1,14 @@
 {% extends 'rest_framework_swagger/base.html' %}
 {% load staticfiles %}
 
+{% block style %}
+    <link href="//fonts.googleapis.com/css?family=Droid+Sans:400,700" rel="stylesheet" type="text/css"/>
+    <link href="{% static 'rest_framework_swagger/css/highlight.default.css' %}" media="screen" rel="stylesheet" type="text/css"/>
+    <link href="{% static 'rest_framework_swagger/css/atelier-dune.light.css' %}" media="screen" rel="stylesheet" type="text/css"/>
+    <link href="{% static 'rest_framework_swagger/css/osf_rest_framework_swagger.css' %}" media="screen" rel="stylesheet" type="text/css"/>
+    <link href="{% static 'rest_framework_swagger/css/osf_screen.css' %}" media="screen" rel="stylesheet" type="text/css"/>
+{% endblock %}
+
 {% block branding %}
     <a id="logo" href="http://osf.io">
         <img class="osf-logo" src="{% static 'rest_framework_swagger/images/cos-white2.png' %}" width="27">


### PR DESCRIPTION
- Load staticfiles in index.html
- Use the `static` prefix instead of hard-coding a path to the image. 
- Also override the style block in index.html instead of modifying base.html directly (not necessary to fix this issue, but this is how we should be changing which css files we're using) 