### PR TITLE
API V2 DRF: Collect static files in static/vendor directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,14 +58,7 @@ website/static/robots.local.txt
 # OSF-specific
 ##############
 
-api/static/rest_framework
-api/static/rest_framework_swagger/css
-api/static/rest_framework_swagger/images
-api/static/rest_framework_swagger/lib
-api/static/rest_framework_swagger/swagger-ui.js
-api/static/rest_framework_swagger/swagger-ui.min.js
-api/static/rest_framework_swagger/o2c.html
-api/static/rest_framework_swagger/index.html
+api/static/vendor
 
 # Local settings files
 local.py

--- a/api/base/settings.py
+++ b/api/base/settings.py
@@ -108,9 +108,9 @@ USE_TZ = True
 
 # https://docs.djangoproject.com/en/1.8/howto/static-files/
 
-STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+STATIC_ROOT = os.path.join(BASE_DIR, 'static/vendor')
 STATIC_URL = '/api/v2/static/'
 STATICFILES_DIRS = (
-    ('rest_framework_swagger/css', os.path.join(STATIC_ROOT, 'css')),
-    ('rest_framework_swagger/images', os.path.join(STATIC_ROOT, 'images')),
+    ('rest_framework_swagger/css', os.path.join(BASE_DIR, 'static/css')),
+    ('rest_framework_swagger/images', os.path.join(BASE_DIR, 'static/images')),
 )


### PR DESCRIPTION
Collect static files in static/vendor (instead of static) so that the entire directory can be excluded from version control. 