### PR TITLE
Add api root docs to swagger docs

### DIFF
--- a/api/base/settings.py
+++ b/api/base/settings.py
@@ -118,3 +118,38 @@ STATICFILES_DIRS = (
     ('rest_framework_swagger/css', os.path.join(BASE_DIR, 'static/css')),
     ('rest_framework_swagger/images', os.path.join(BASE_DIR, 'static/images')),
 )
+
+SWAGGER_SETTINGS = {
+    'info': {
+        'description':
+            '<p>Welcome to the V2 Open Science Framework API. Once this clause disappears from this sentence, the V2 API will be the first supported, public REST API for the Open Science Framework.'
+            + 'We will define what the expected limits of the support are before this goes live, but for now I expect that this will be functional until we have at least the V3 API in place and '
+            + 'possibly the V4. There may be additions to the V2 API, but no changes or deletions to the routes and returns. Links to services external to the OSF may change (see below), so following '
+            + 'our development guidelines will be useful for maintaining compatibility.<p>'
+            + '<p>Each endpoint will have its own documentation, but there are some general things that should work pretty much everywhere.</p>'
+            + '<h2>Filtering</h2>'
+            + '<p>Collections can be filtered by adding a query parameter in the form:</p>'
+            + '<pre>filter[&lt;fieldname&gt;]=&lt;matching information&gt;</pre>'
+            + '<p>For example, if you were trying to find <a href="http://en.wikipedia.org/wiki/Lise_Meitner">Lise Metiner</a>:</p>'
+            + '<pre>/users?filter[fullname]=meitn</pre>'
+            + '<p>You can filter on multiple fields, or the same field in different ways, by &-ing the query parameters together.</p>'
+            + '<pre>/users?filter[fullname]=lise&filter[family_name]=mei</pre>'
+            + '<h2>Links</h2>'
+            + '<p>Responses will generally have associated links. These are helpers to keep you from having to construct '
+            + 'URLs in your code or by hand. If you know the route to a high-level resource, then feel free to just go to that '
+            + 'route. For example, going to:</p>'
+            + '<pre>/nodes/&lt;node_id&gt;</pre>'
+            + '<p>is a perfectly good route to create rather than going to /nodes/ and navigating from there by filtering by id '
+            + '(which would be ridiculous). However, if you are creating something that crawls the structure of a node '
+            + 'going to child node or gathering children, contributors, and similar related resources, then grab the link from '
+            + 'the object you\'re crawling rather than constructing the link yourself. '
+            + 'In general, links include:</p>'
+            + '<ol>'
+            + '<li>1. "Related" links, which will give you detail information on individual items or a collection of related resources;</li>'
+            + '<li>2. "Self" links, which is what you use for general REST operations (POST, DELETE, and so on);</li>'
+            + '<li>3. Pagination links such as "next", "prev", "first", and "last". These are great for navigating long lists of information.</li></ol>'
+            + '<p>Some routes may have extra rules for links, especially if those links work with external services. Collections '
+            + 'may have counts with them to indicate how many items are in that collection.</p>',
+        'title': 'OSF API Documentation'
+    }
+}

--- a/api/static/css/osf_screen.css
+++ b/api/static/css/osf_screen.css
@@ -248,9 +248,11 @@
 }
 .swagger-ui-wrap pre {
   font-family: "Anonymous Pro", "Menlo", "Consolas", "Bitstream Vera Sans Mono", "Courier New", monospace;
+  font-size: 12px;
   background-color: #fcf6db;
   border: 1px solid #e5e0c6;
   padding: 10px;
+  margin-bottom: 10px;
 }
 .swagger-ui-wrap pre code {
   line-height: 1.6em;


### PR DESCRIPTION
Fixes #48 

The django-rest-swagger docs do not include the information provided in the api root endpoint. Include this documentation in `SWAGGER_SETTINGS.info.description` so that it is included on the "root" docs page `/docs/`: 

![screen shot 2015-05-12 at 1 02 50 pm](https://cloud.githubusercontent.com/assets/6414394/7593316/3ceaefb2-f8a7-11e4-882c-e09f5b8f3c7b.png)
