### PR TITLE
API V2 DRF: node files tests

### DIFF
--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -1,6 +1,7 @@
 import requests
 
 from rest_framework import generics, permissions as drf_permissions
+from rest_framework.exceptions import PermissionDenied
 from modularodm import Q
 
 from framework.auth.core import Auth
@@ -251,8 +252,10 @@ class NodeFilesList(generics.ListAPIView, NodeMixin):
                         'metadata': {},
                     })
         else:
-            url = waterbutler_url_for('data', provider, path, self.kwargs['pk'], node_id, obj_args)
+            url = waterbutler_url_for('data', provider, path, self.kwargs['pk'], cookie, obj_args)
             waterbutler_request = requests.get(url)
+            if waterbutler_request.status_code == 401:
+                raise PermissionDenied
             waterbutler_data = waterbutler_request.json()['data']
             if isinstance(waterbutler_data, list):
                 for item in waterbutler_data:

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -1,7 +1,7 @@
 import requests
 
 from rest_framework import generics, permissions as drf_permissions
-from rest_framework.exceptions import PermissionDenied
+from rest_framework.exceptions import PermissionDenied, ValidationError
 from modularodm import Q
 
 from framework.auth.core import Auth
@@ -256,7 +256,11 @@ class NodeFilesList(generics.ListAPIView, NodeMixin):
             waterbutler_request = requests.get(url)
             if waterbutler_request.status_code == 401:
                 raise PermissionDenied
-            waterbutler_data = waterbutler_request.json()['data']
+            try:
+                waterbutler_data = waterbutler_request.json()['data']
+            except KeyError:
+                raise ValidationError(detail='detail: Could not retrieve files information.')
+
             if isinstance(waterbutler_data, list):
                 for item in waterbutler_data:
                     file = self.get_file_item(item, cookie, obj_args)

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import mock
 from nose.tools import *  # flake8: noqa
 
 from framework.auth.core import Auth
@@ -6,6 +7,70 @@ from website.models import Node
 from website.util import api_v2_url_for
 from tests.base import OsfTestCase, fake
 from tests.factories import UserFactory, ProjectFactory, FolderFactory, DashboardFactory
+
+
+class TestNodeFilesList(OsfTestCase):
+
+    def setUp(self):
+        OsfTestCase.setUp(self)
+        self.user = UserFactory.build()
+        self.user.set_password('justapoorboy')
+        self.user.save()
+        self.auth = (self.user.username, 'justapoorboy')
+        self.project = ProjectFactory(creator=self.user)
+
+    def test_returns_200(self):
+        url = api_v2_url_for('nodes:node-files', kwargs=dict(pk=self.project._id))
+        res = self.app.get(url, auth=self.auth)
+        assert_equal(res.status_code, 200)
+
+    def test_returns_osfstorage_folder(self):
+        url = api_v2_url_for('nodes:node-files', kwargs=dict(pk=self.project._id))
+        res = self.app.get(url, auth=self.auth)
+        assert_equal(res.json['data'][0]['provider'], 'osfstorage')
+
+    def test_returns_addon_folders(self):
+        project = ProjectFactory(creator=self.user)
+        project.add_addon('github', auth=Auth(self.user))
+        project.save()
+
+        url = api_v2_url_for('nodes:node-files', kwargs=dict(pk=project._id))
+        res = self.app.get(url, auth=self.auth)
+        data = res.json['data']
+        assert_equal(len(data), 2)
+        assert_equal(data[0]['provider'], 'github')
+        assert_equal(data[1]['provider'], 'osfstorage')
+
+    @mock.patch('api.nodes.views.requests.get')
+    def test_returns_node_files_list(self, mock_waterbutler_request):
+        mock_res = mock.MagicMock()
+        mock_res.status_code = 200
+        mock_res.json.return_value = {
+            u'data': [{
+                u'contentType': None,
+                u'extra': {u'downloads': 0, u'version': 1},
+                u'kind': u'file',
+                u'modified': None,
+                u'name': u'NewFile',
+                u'path': u'/',
+                u'provider': u'osfstorage',
+                u'size': None
+            }]
+        }
+        mock_waterbutler_request.return_value = mock_res
+        url = api_v2_url_for('nodes:node-files', kwargs=dict(pk=self.project._id)) + '?path=%2F&provider=osfstorage'
+        res = self.app.get(url, auth=self.auth)
+        assert_equal(res.json['data'][0]['name'], 'NewFile')
+        assert_equal(res.json['data'][0]['provider'], 'osfstorage')
+
+    @mock.patch('api.nodes.views.requests.get')
+    def test_handles_unauthenticated_waterbutler_request(self, mock_waterbutler_request):
+        url = api_v2_url_for('nodes:node-files', kwargs=dict(pk=self.project._id)) + '?path=%2F&provider=osfstorage'
+        mock_res = mock.MagicMock()
+        mock_res.status_code = 401
+        mock_waterbutler_request.return_value = mock_res
+        res = self.app.get(url, auth=self.auth, expect_errors=True)
+        assert_equal(res.status_code, 403)
 
 
 class TestNodeList(OsfTestCase):

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -9,70 +9,6 @@ from tests.base import OsfTestCase, fake
 from tests.factories import UserFactory, ProjectFactory, FolderFactory, DashboardFactory
 
 
-class TestNodeFilesList(OsfTestCase):
-
-    def setUp(self):
-        OsfTestCase.setUp(self)
-        self.user = UserFactory.build()
-        self.user.set_password('justapoorboy')
-        self.user.save()
-        self.auth = (self.user.username, 'justapoorboy')
-        self.project = ProjectFactory(creator=self.user)
-
-    def test_returns_200(self):
-        url = api_v2_url_for('nodes:node-files', kwargs=dict(pk=self.project._id))
-        res = self.app.get(url, auth=self.auth)
-        assert_equal(res.status_code, 200)
-
-    def test_returns_osfstorage_folder(self):
-        url = api_v2_url_for('nodes:node-files', kwargs=dict(pk=self.project._id))
-        res = self.app.get(url, auth=self.auth)
-        assert_equal(res.json['data'][0]['provider'], 'osfstorage')
-
-    def test_returns_addon_folders(self):
-        project = ProjectFactory(creator=self.user)
-        project.add_addon('github', auth=Auth(self.user))
-        project.save()
-
-        url = api_v2_url_for('nodes:node-files', kwargs=dict(pk=project._id))
-        res = self.app.get(url, auth=self.auth)
-        data = res.json['data']
-        assert_equal(len(data), 2)
-        assert_equal(data[0]['provider'], 'github')
-        assert_equal(data[1]['provider'], 'osfstorage')
-
-    @mock.patch('api.nodes.views.requests.get')
-    def test_returns_node_files_list(self, mock_waterbutler_request):
-        mock_res = mock.MagicMock()
-        mock_res.status_code = 200
-        mock_res.json.return_value = {
-            u'data': [{
-                u'contentType': None,
-                u'extra': {u'downloads': 0, u'version': 1},
-                u'kind': u'file',
-                u'modified': None,
-                u'name': u'NewFile',
-                u'path': u'/',
-                u'provider': u'osfstorage',
-                u'size': None
-            }]
-        }
-        mock_waterbutler_request.return_value = mock_res
-        url = api_v2_url_for('nodes:node-files', kwargs=dict(pk=self.project._id)) + '?path=%2F&provider=osfstorage'
-        res = self.app.get(url, auth=self.auth)
-        assert_equal(res.json['data'][0]['name'], 'NewFile')
-        assert_equal(res.json['data'][0]['provider'], 'osfstorage')
-
-    @mock.patch('api.nodes.views.requests.get')
-    def test_handles_unauthenticated_waterbutler_request(self, mock_waterbutler_request):
-        url = api_v2_url_for('nodes:node-files', kwargs=dict(pk=self.project._id)) + '?path=%2F&provider=osfstorage'
-        mock_res = mock.MagicMock()
-        mock_res.status_code = 401
-        mock_waterbutler_request.return_value = mock_res
-        res = self.app.get(url, auth=self.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
-
-
 class TestNodeList(OsfTestCase):
 
     def setUp(self):
@@ -465,3 +401,67 @@ class TestNodePointerDetail(OsfTestCase):
         res = self.app.delete(url, auth=self.auth)
         assert_equal(res.status_code, 204)
         assert_equal(len(self.project.nodes_pointer), 0)
+
+
+class TestNodeFilesList(OsfTestCase):
+
+    def setUp(self):
+        OsfTestCase.setUp(self)
+        self.user = UserFactory.build()
+        self.user.set_password('justapoorboy')
+        self.user.save()
+        self.auth = (self.user.username, 'justapoorboy')
+        self.project = ProjectFactory(creator=self.user)
+
+    def test_returns_200(self):
+        url = api_v2_url_for('nodes:node-files', kwargs=dict(pk=self.project._id))
+        res = self.app.get(url, auth=self.auth)
+        assert_equal(res.status_code, 200)
+
+    def test_returns_addon_folders(self):
+        project = ProjectFactory(creator=self.user)
+        url = api_v2_url_for('nodes:node-files', kwargs=dict(pk=project._id))
+        res = self.app.get(url, auth=self.auth)
+        assert_equal(len(res.json['data']), 1)
+        assert_equal(res.json['data'][0]['provider'], 'osfstorage')
+
+        project.add_addon('github', auth=Auth(self.user))
+        project.save()
+
+        res = self.app.get(url, auth=self.auth)
+        data = res.json['data']
+        providers = [item['provider'] for item in data]
+        assert_equal(len(data), 2)
+        assert_in('github', providers)
+        assert_in('osfstorage', providers)
+
+    @mock.patch('api.nodes.views.requests.get')
+    def test_returns_node_files_list(self, mock_waterbutler_request):
+        mock_res = mock.MagicMock()
+        mock_res.status_code = 200
+        mock_res.json.return_value = {
+            u'data': [{
+                u'contentType': None,
+                u'extra': {u'downloads': 0, u'version': 1},
+                u'kind': u'file',
+                u'modified': None,
+                u'name': u'NewFile',
+                u'path': u'/',
+                u'provider': u'osfstorage',
+                u'size': None
+            }]
+        }
+        mock_waterbutler_request.return_value = mock_res
+        url = api_v2_url_for('nodes:node-files', kwargs=dict(pk=self.project._id)) + '?path=%2F&provider=osfstorage'
+        res = self.app.get(url, auth=self.auth)
+        assert_equal(res.json['data'][0]['name'], 'NewFile')
+        assert_equal(res.json['data'][0]['provider'], 'osfstorage')
+
+    @mock.patch('api.nodes.views.requests.get')
+    def test_handles_unauthenticated_waterbutler_request(self, mock_waterbutler_request):
+        url = api_v2_url_for('nodes:node-files', kwargs=dict(pk=self.project._id)) + '?path=%2F&provider=osfstorage'
+        mock_res = mock.MagicMock()
+        mock_res.status_code = 401
+        mock_waterbutler_request.return_value = mock_res
+        res = self.app.get(url, auth=self.auth, expect_errors=True)
+        assert_equal(res.status_code, 403)

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -465,3 +465,13 @@ class TestNodeFilesList(OsfTestCase):
         mock_waterbutler_request.return_value = mock_res
         res = self.app.get(url, auth=self.auth, expect_errors=True)
         assert_equal(res.status_code, 403)
+
+    @mock.patch('api.nodes.views.requests.get')
+    def test_handles_bad_waterbutler_request(self, mock_waterbutler_request):
+        url = api_v2_url_for('nodes:node-files', kwargs=dict(pk=self.project._id)) + '?path=%2F&provider=osfstorage'
+        mock_res = mock.MagicMock()
+        mock_res.status_code = 418
+        mock_res.json.return_value = {}
+        mock_waterbutler_request.return_value = mock_res
+        res = self.app.get(url, auth=self.auth, expect_errors=True)
+        assert_equal(res.status_code, 400)


### PR DESCRIPTION
- Add views tests for the nodes/files api endpoint (Fixes #39).  
- Fix waterbutler url to include the user's cookie as the token instead of the node id.
- Add error handling for unauthenticated requests to waterbutler (Partially addresses #57). 