### PR TITLE
API V2 DRF: Change base route for django app to 'v2'

### DIFF
--- a/api/base/settings.py
+++ b/api/base/settings.py
@@ -113,7 +113,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.8/howto/static-files/
 
 STATIC_ROOT = os.path.join(BASE_DIR, 'static/vendor')
-STATIC_URL = '/api/v2/static/'
+STATIC_URL = '/api/static/'
 STATICFILES_DIRS = (
     ('rest_framework_swagger/css', os.path.join(BASE_DIR, 'static/css')),
     ('rest_framework_swagger/images', os.path.join(BASE_DIR, 'static/images')),

--- a/api/base/urls.py
+++ b/api/base/urls.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.conf.urls import include, url
+from django.conf.urls import include, url, patterns
 # from django.contrib import admin
 from django.conf.urls.static import static
 
@@ -9,8 +9,9 @@ from . import views
 
 urlpatterns = [
     ### API ###
-    url(r'^$', views.root),
-    url(r'^nodes/', include('api.nodes.urls', namespace='nodes')),
-    url(r'^users/', include('api.users.urls', namespace='users')),
-    url(r'^docs/', include('rest_framework_swagger.urls')),
-] + static('/static/', document_root=settings.STATIC_ROOT)
+    url(r'^v2/', include(patterns('',
+        url(r'^$', views.root),
+        url(r'^nodes/', include('api.nodes.urls', namespace='nodes')),
+        url(r'^users/', include('api.users.urls', namespace='users')),
+        url(r'^docs/', include('rest_framework_swagger.urls')),
+    )))] + static('/static/', document_root=settings.STATIC_ROOT)

--- a/website/app.py
+++ b/website/app.py
@@ -159,6 +159,6 @@ def apply_middlewares(flask_app, settings):
         flask_app.wsgi_app = ProxyFix(flask_app.wsgi_app)
 
     flask_app.wsgi_app = DispatcherMiddleware(flask_app.wsgi_app, {
-        '/api/v2': django_app,
+        '/api': django_app,
     })
     return flask_app

--- a/website/static/js/resources/base.js
+++ b/website/static/js/resources/base.js
@@ -8,7 +8,7 @@ var $ = require('jquery');
 var DOMAIN = '';
 
 var BaseClient = oop.defclass({
-    PREFIX: '/api/v2',
+    PREFIX: '/api',
     DEFAULT_AJAX_OPTIONS: {
         contentType: 'application/json',
         dataType: 'json'

--- a/website/util/__init__.py
+++ b/website/util/__init__.py
@@ -39,7 +39,7 @@ def _get_guid_url_for(url):
     return guid_url
 
 def api_v2_url_for(*args, **kwargs):
-    return reverse(prefix='/api/v2/', *args, **kwargs)
+    return reverse(prefix='/api/', *args, **kwargs)
 
 
 def api_url_for(view_name, _absolute=False, _offload=False, _xml=False, *args, **kwargs):


### PR DESCRIPTION
Fixes #50 

- Add `/v2/`prefix to api urls
- Change osf api prefix from `/api/v2` to `/api` because otherwise, it's prefix would be `/api/v2/v2`