### PR TITLE
Feature/fix node children

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -63,7 +63,11 @@ class NodeSerializer(JSONAPISerializer):
         return obj.absolute_url
 
     def get_node_count(self, obj):
-        return len(obj.nodes)
+        request = self.context['request']
+        user = request.user
+        auth = Auth(user)
+        nodes = [node for node in obj.nodes if node.can_view(auth) and node.primary]
+        return len(nodes)
 
     def get_contrib_count(self, obj):
         return len(obj.contributors)

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -166,7 +166,7 @@ class NodeChildrenList(generics.ListAPIView, NodeMixin):
     def get_queryset(self):
         nodes = self.get_node().nodes
         auth = Auth(self.request.user)
-        children = [node for node in nodes if node.can_view(auth)]
+        children = [node for node in nodes if node.can_view(auth) and node.primary]
         return children
 
 


### PR DESCRIPTION
Fixes #58 - Now pointers are not included in the the node children endpoint or the count.  

Related to #59 - Since the node children endpoint only returns nodes that the user is authorized to see, the count was updated so that it is consistent. 