### PR TITLE
API V2 DRF: Fix server crash when DEBUG_MODE = False

### DIFF
--- a/api/base/settings.py
+++ b/api/base/settings.py
@@ -28,7 +28,9 @@ AUTHENTICATION_BACKENDS = (
 DEBUG = osf_settings.DEBUG_MODE
 
 ALLOWED_HOSTS = [
-    '.osf.io'
+    '.osf.io',
+    'localhost',
+    '127.0.0.1'
 ]
 
 


### PR DESCRIPTION
Include localhost in `ALLOWED_HOSTS` to allow the django app to run on localhost when `DEBUG = False` (Fixes #20). See https://docs.djangoproject.com/en/1.8/ref/settings/#allowed-hosts

Note that django does not load static files when `DEBUG = False`, so this will have to be configured before we can deploy to production: https://docs.djangoproject.com/en/1.8/howto/static-files/deployment/