### PR TITLE
API V2 DRF: Fix api routes and remove DispatcherMiddleware

### DIFF
--- a/api/base/settings.py
+++ b/api/base/settings.py
@@ -113,7 +113,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.8/howto/static-files/
 
 STATIC_ROOT = os.path.join(BASE_DIR, 'static/vendor')
-STATIC_URL = '/api/v2/static/'
+STATIC_URL = '/api/static/'
 STATICFILES_DIRS = (
     ('rest_framework_swagger/css', os.path.join(BASE_DIR, 'static/css')),
     ('rest_framework_swagger/images', os.path.join(BASE_DIR, 'static/images')),

--- a/api/base/urls.py
+++ b/api/base/urls.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.conf.urls import include, url
+from django.conf.urls import include, url, patterns
 # from django.contrib import admin
 from django.conf.urls.static import static
 
@@ -9,8 +9,9 @@ from . import views
 
 urlpatterns = [
     ### API ###
-    url(r'^$', views.root),
-    url(r'^nodes/', include('api.nodes.urls', namespace='nodes')),
-    url(r'^users/', include('api.users.urls', namespace='users')),
-    url(r'^docs/', include('rest_framework_swagger.urls')),
-] + static('/static/', document_root=settings.STATIC_ROOT)
+    url(r'^v2/', include(patterns('',
+        url(r'^$', views.root),
+        url(r'^nodes/', include('api.nodes.urls', namespace='nodes')),
+        url(r'^users/', include('api.users.urls', namespace='users')),
+        url(r'^docs/', include('rest_framework_swagger.urls')),
+    )))] + static('/static/', document_root=settings.STATIC_ROOT)

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -5,14 +5,14 @@ from nose.tools import *  # flake8: noqa
 from framework.auth.core import Auth
 from website.models import Node
 from website.util import api_v2_url_for
-from tests.base import OsfTestCase, fake
+from tests.base import ApiTestCase, fake
 from tests.factories import UserFactory, ProjectFactory, FolderFactory, DashboardFactory, NodeFactory, PointerFactory
 
 
-class TestNodeList(OsfTestCase):
+class TestNodeList(ApiTestCase):
 
     def setUp(self):
-        OsfTestCase.setUp(self)
+        ApiTestCase.setUp(self)
         self.user = UserFactory.build()
         self.user.set_password('justapoorboy')
         self.user.save()
@@ -39,10 +39,10 @@ class TestNodeList(OsfTestCase):
         Node.remove()
 
 
-class TestNodeContributorList(OsfTestCase):
+class TestNodeContributorList(ApiTestCase):
 
     def setUp(self):
-        OsfTestCase.setUp(self)
+        ApiTestCase.setUp(self)
         self.user = UserFactory.build()
 
         password = fake.password()
@@ -78,9 +78,9 @@ class TestNodeContributorList(OsfTestCase):
         Node.remove()
 
 
-class TestNodeChildrenList(OsfTestCase):
+class TestNodeChildrenList(ApiTestCase):
     def setUp(self):
-        OsfTestCase.setUp(self)
+        ApiTestCase.setUp(self)
         self.user = UserFactory.build()
         password = fake.password()
         self.password = password
@@ -106,10 +106,10 @@ class TestNodeChildrenList(OsfTestCase):
         assert_equal(len(res.json['data']), 1)
 
 
-class TestNodeFiltering(OsfTestCase):
+class TestNodeFiltering(ApiTestCase):
 
     def setUp(self):
-        OsfTestCase.setUp(self)
+        ApiTestCase.setUp(self)
         self.user_one = UserFactory.build()
         self.user_one.set_password('justapoorboy')
         self.user_one.save()
@@ -127,7 +127,7 @@ class TestNodeFiltering(OsfTestCase):
         self.dashboard = DashboardFactory()
 
     def tearDown(self):
-        OsfTestCase.tearDown(self)
+        ApiTestCase.tearDown(self)
         Node.remove()
 
     def test_get_all_projects_with_no_filter_logged_in(self):
@@ -313,10 +313,10 @@ class TestNodeFiltering(OsfTestCase):
         assert_not_in(self.dashboard._id, ids)
 
 
-class TestNodePointersList(OsfTestCase):
+class TestNodePointersList(ApiTestCase):
 
     def setUp(self):
-        OsfTestCase.setUp(self)
+        ApiTestCase.setUp(self)
         self.user = UserFactory.build()
         self.user.set_password('password')
         self.user.save()
@@ -346,7 +346,7 @@ class TestNodePointersList(OsfTestCase):
         assert_equal(res.json['data']['node_id'], project._id)
 
 
-class TestNodeContributorFiltering(OsfTestCase):
+class TestNodeContributorFiltering(ApiTestCase):
 
     def test_filtering_node_with_only_bibliographic_contributors(self):
         project = ProjectFactory()
@@ -401,10 +401,10 @@ class TestNodeContributorFiltering(OsfTestCase):
         assert_false(res.json['data'][0].get('bibliographic', None))
 
 
-class TestNodePointerDetail(OsfTestCase):
+class TestNodePointerDetail(ApiTestCase):
 
     def setUp(self):
-        OsfTestCase.setUp(self)
+        ApiTestCase.setUp(self)
         self.user = UserFactory.build()
         self.user.set_password('password')
         self.user.save()
@@ -431,10 +431,10 @@ class TestNodePointerDetail(OsfTestCase):
         assert_equal(len(self.project.nodes_pointer), 0)
 
 
-class TestNodeFilesList(OsfTestCase):
+class TestNodeFilesList(ApiTestCase):
 
     def setUp(self):
-        OsfTestCase.setUp(self)
+        ApiTestCase.setUp(self)
         self.user = UserFactory.build()
         self.user.set_password('justapoorboy')
         self.user.save()

--- a/tests/base.py
+++ b/tests/base.py
@@ -16,7 +16,9 @@ from faker import Factory
 from nose.tools import *  # noqa (PEP8 asserts)
 from pymongo.errors import OperationFailure
 from modularodm import storage
+from werkzeug.wsgi import DispatcherMiddleware
 
+from api.base.wsgi import application as django_app
 from framework.mongo import set_up_storage
 from framework.auth import User
 from framework.sessions.model import Session
@@ -42,6 +44,14 @@ test_app = init_app(
     settings_module='website.settings', routes=True, set_backends=False
 )
 test_app.testing = True
+
+
+test_api = init_app(
+    settings_module='website.settings', routes=True, set_backends=False
+)
+test_api.wsgi_app = DispatcherMiddleware(test_api.wsgi_app, {
+    '/api/v2': django_app,
+})
 
 
 # Silence some 3rd-party logging and some "loud" internal loggers
@@ -147,6 +157,20 @@ class AppTestCase(unittest.TestCase):
         self.context.pop()
 
 
+class ApiAppTestCase(unittest.TestCase):
+    """Base `TestCase` for OSF tests that require the WSGI app (but no database).
+    """
+
+    def setUp(self):
+        super(ApiAppTestCase, self).setUp()
+        self.app = TestApp(test_api)
+        self.context = test_api.test_request_context()
+        self.context.push()
+
+    def tearDown(self):
+        super(ApiAppTestCase, self).tearDown()
+        self.context.pop()
+
 class UploadTestCase(unittest.TestCase):
 
     @classmethod
@@ -209,6 +233,14 @@ class MockRequestTestCase(unittest.TestCase):
 
 
 class OsfTestCase(DbTestCase, AppTestCase, UploadTestCase, MockRequestTestCase):
+    """Base `TestCase` for tests that require both scratch databases and the OSF
+    application. Note: superclasses must call `super` in order for all setup and
+    teardown methods to be called correctly.
+    """
+    pass
+
+
+class ApiTestCase(DbTestCase, ApiAppTestCase, UploadTestCase, MockRequestTestCase):
     """Base `TestCase` for tests that require both scratch databases and the OSF
     application. Note: superclasses must call `super` in order for all setup and
     teardown methods to be called correctly.

--- a/tests/base.py
+++ b/tests/base.py
@@ -50,7 +50,7 @@ test_api = init_app(
     settings_module='website.settings', routes=True, set_backends=False
 )
 test_api.wsgi_app = DispatcherMiddleware(test_api.wsgi_app, {
-    '/api/v2': django_app,
+    '/api': django_app,
 })
 
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -45,7 +45,7 @@ test_app = init_app(
 )
 test_app.testing = True
 
-
+# Test app that connects to the django app
 test_api = init_app(
     settings_module='website.settings', routes=True, set_backends=False
 )
@@ -158,7 +158,7 @@ class AppTestCase(unittest.TestCase):
 
 
 class ApiAppTestCase(unittest.TestCase):
-    """Base `TestCase` for OSF tests that require the WSGI app (but no database).
+    """Base `TestCase` for OSF API tests that require the WSGI app (but no database).
     """
 
     def setUp(self):
@@ -242,7 +242,7 @@ class OsfTestCase(DbTestCase, AppTestCase, UploadTestCase, MockRequestTestCase):
 
 class ApiTestCase(DbTestCase, ApiAppTestCase, UploadTestCase, MockRequestTestCase):
     """Base `TestCase` for tests that require both scratch databases and the OSF
-    application. Note: superclasses must call `super` in order for all setup and
+    API application. Note: superclasses must call `super` in order for all setup and
     teardown methods to be called correctly.
     """
     pass

--- a/website/app.py
+++ b/website/app.py
@@ -158,7 +158,4 @@ def apply_middlewares(flask_app, settings):
     if settings.LOAD_BALANCER:
         flask_app.wsgi_app = ProxyFix(flask_app.wsgi_app)
 
-    flask_app.wsgi_app = DispatcherMiddleware(flask_app.wsgi_app, {
-        '/api/v2': django_app,
-    })
     return flask_app

--- a/website/static/js/resources/base.js
+++ b/website/static/js/resources/base.js
@@ -8,7 +8,7 @@ var $ = require('jquery');
 var DOMAIN = '';
 
 var BaseClient = oop.defclass({
-    PREFIX: '/api/v2',
+    PREFIX: '/api',
     DEFAULT_AJAX_OPTIONS: {
         contentType: 'application/json',
         dataType: 'json'

--- a/website/util/__init__.py
+++ b/website/util/__init__.py
@@ -39,7 +39,7 @@ def _get_guid_url_for(url):
     return guid_url
 
 def api_v2_url_for(*args, **kwargs):
-    return reverse(prefix='/api/v2/', *args, **kwargs)
+    return reverse(prefix='/api/', *args, **kwargs)
 
 
 def api_url_for(view_name, _absolute=False, _offload=False, _xml=False, *args, **kwargs):


### PR DESCRIPTION
Fixes the broken tests in https://github.com/brianjgeiger/osf.io/pull/63 
Addresses issue #50 

Removes the DispatcherMiddleware for the api so that it is no longer included in the osf application. Also, includes an ApiTestCase so that the api tests will still pass. 