### PR TITLE
Fix API V2 ApiTestCase

### DIFF
--- a/tests/api_tests/base/test_views.py
+++ b/tests/api_tests/base/test_views.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 from nose.tools import *  # flake8: noqa
 
-from tests.base import OsfTestCase
+from tests.base import ApiTestCase
 
-class TestApiBaseViews(OsfTestCase):
+class TestApiBaseViews(ApiTestCase):
 
     def test_root_returns_200(self):
-        res = self.app.get('/api/v2/')
+        res = self.app.get('/v2/')
         assert_equal(res.status_code, 200)
 
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -45,14 +45,6 @@ test_app = init_app(
 )
 test_app.testing = True
 
-# Test app that connects to the django app
-test_api = init_app(
-    settings_module='website.settings', routes=True, set_backends=False
-)
-test_api.wsgi_app = DispatcherMiddleware(test_api.wsgi_app, {
-    '': django_app,
-})
-
 
 # Silence some 3rd-party logging and some "loud" internal loggers
 SILENT_LOGGERS = [
@@ -163,13 +155,8 @@ class ApiAppTestCase(unittest.TestCase):
 
     def setUp(self):
         super(ApiAppTestCase, self).setUp()
-        self.app = TestApp(test_api)
-        self.context = test_api.test_request_context()
-        self.context.push()
+        self.app = TestApp(django_app)
 
-    def tearDown(self):
-        super(ApiAppTestCase, self).tearDown()
-        self.context.pop()
 
 class UploadTestCase(unittest.TestCase):
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -16,7 +16,6 @@ from faker import Factory
 from nose.tools import *  # noqa (PEP8 asserts)
 from pymongo.errors import OperationFailure
 from modularodm import storage
-from werkzeug.wsgi import DispatcherMiddleware
 
 from api.base.wsgi import application as django_app
 from framework.mongo import set_up_storage


### PR DESCRIPTION
Instead of connecting a test app to the django app and setting a flask request context, wrap the django app directly.