### PR TITLE
Add tests for node permissions

### DIFF
--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -15,7 +15,7 @@ class TestWelcomeToApi(ApiTestCase):
         self.user = UserFactory.build()
         self.user.set_password('justapoorboy')
         self.user.save()
-        self.auth = (self.user.username, 'justapoorboy')
+        self.basic_auth = (self.user.username, 'justapoorboy')
         self.url = '/v2/'
 
     def test_returns_200_for_logged_out_user(self):
@@ -24,7 +24,7 @@ class TestWelcomeToApi(ApiTestCase):
         assert_equal(res.json['meta']['current_user'], None)
 
     def test_returns_current_user_info_when_logged_in(self):
-        res = self.app.get(self.url, auth=self.auth)
+        res = self.app.get(self.url, auth=self.basic_auth)
         assert_equal(res.status_code, 200)
         assert_equal(res.json['meta']['current_user']['data']['given_name'], self.user.given_name)
 
@@ -34,22 +34,18 @@ class TestNodeList(ApiTestCase):
         self.user = UserFactory.build()
         self.user.set_password('justapoorboy')
         self.user.save()
-        self.auth = (self.user.username, 'justapoorboy')
+        self.basic_auth = (self.user.username, 'justapoorboy')
 
         self.non_contrib = UserFactory.build()
         self.non_contrib.set_password('justapoorboy')
         self.non_contrib.save()
-        self.non_contrib_auth = (self.non_contrib.username, 'justapoorboy')
+        self.basic_non_contrib_auth = (self.non_contrib.username, 'justapoorboy')
 
         self.deleted = ProjectFactory(is_deleted=True)
         self.private = ProjectFactory(is_public=False, creator=self.user)
         self.public = ProjectFactory(is_public=True, creator=self.user)
 
         self.url = '/v2/nodes/'
-
-    def test_returns_200(self):
-        res = self.app.get(self.url)
-        assert_equal(res.status_code, 200)
 
     def test_only_returns_non_deleted_public_projects(self):
         res = self.app.get(self.url)
@@ -81,15 +77,14 @@ class TestNodeList(ApiTestCase):
         assert_not_in(self.private._id, ids)
 
     def test_return_private_node_list_logged_in_contributor(self):
-        res = self.app.get(self.url, auth=self.auth)
+        res = self.app.get(self.url, auth=self.basic_auth)
         assert_equal(res.status_code, 200)
-        assert_equal(len(res.json['data']), 2)
         ids = [each['id'] for each in res.json['data']]
         assert_in(self.public._id, ids)
         assert_in(self.private._id, ids)
 
     def test_return_private_node_list_logged_in_non_contributor(self):
-        res = self.app.get(self.url, auth=self.non_contrib)
+        res = self.app.get(self.url, auth=self.basic_non_contrib_auth)
         ids = [each['id'] for each in res.json['data']]
         assert_in(self.public._id, ids)
         assert_not_in(self.private._id, ids)
@@ -103,11 +98,11 @@ class TestNodeFiltering(ApiTestCase):
         self.user_one = UserFactory.build()
         self.user_one.set_password('justapoorboy')
         self.user_one.save()
-        self.auth_one = (self.user_one.username, 'justapoorboy')
+        self.basic_auth_one = (self.user_one.username, 'justapoorboy')
         self.user_two = UserFactory.build()
         self.user_two.set_password('justapoorboy')
         self.user_two.save()
-        self.auth_two = (self.user_two.username, 'justapoorboy')
+        self.basic_auth_two = (self.user_two.username, 'justapoorboy')
         self.project_one = ProjectFactory(title="Project One", is_public=True)
         self.project_two = ProjectFactory(title="Project Two", description="One Three", is_public=True)
         self.project_three = ProjectFactory(title="Three", is_public=True)
@@ -116,14 +111,14 @@ class TestNodeFiltering(ApiTestCase):
         self.folder = FolderFactory()
         self.dashboard = DashboardFactory()
 
+        self.url = "/v2/nodes/"
+
     def tearDown(self):
         ApiTestCase.tearDown(self)
         Node.remove()
 
     def test_get_all_projects_with_no_filter_logged_in(self):
-        url = "/v2/nodes/"
-
-        res = self.app.get(url, auth=self.auth_one)
+        res = self.app.get(self.url, auth=self.basic_auth_one)
         node_json = res.json['data']
 
         ids = [each['id'] for each in node_json]
@@ -136,9 +131,7 @@ class TestNodeFiltering(ApiTestCase):
         assert_not_in(self.dashboard._id, ids)
 
     def test_get_all_projects_with_no_filter_not_logged_in(self):
-        url = "/v2/nodes/"
-
-        res = self.app.get(url)
+        res = self.app.get(self.url)
         node_json = res.json['data']
         ids = [each['id'] for each in node_json]
         assert_in(self.project_one._id, ids)
@@ -152,7 +145,7 @@ class TestNodeFiltering(ApiTestCase):
     def test_get_one_project_with_exact_filter_logged_in(self):
         url = "/v2/nodes/?filter[title]=Project%20One"
 
-        res = self.app.get(url, auth=self.auth_one)
+        res = self.app.get(url, auth=self.basic_auth_one)
         node_json = res.json['data']
 
         ids = [each['id'] for each in node_json]
@@ -182,7 +175,7 @@ class TestNodeFiltering(ApiTestCase):
     def test_get_some_projects_with_substring_logged_in(self):
         url = "/v2/nodes/?filter[title]=Two"
 
-        res = self.app.get(url, auth=self.auth_one)
+        res = self.app.get(url, auth=self.basic_auth_one)
         node_json = res.json['data']
 
         ids = [each['id'] for each in node_json]
@@ -197,7 +190,7 @@ class TestNodeFiltering(ApiTestCase):
     def test_get_some_projects_with_substring_not_logged_in(self):
         url = "/v2/nodes/?filter[title]=Two"
 
-        res = self.app.get(url, auth=self.auth_one)
+        res = self.app.get(url, auth=self.basic_auth_one)
         node_json = res.json['data']
 
         ids = [each['id'] for each in node_json]
@@ -212,7 +205,7 @@ class TestNodeFiltering(ApiTestCase):
     def test_get_only_public_or_my_projects_with_filter_logged_in(self):
         url = "/v2/nodes/?filter[title]=Project"
 
-        res = self.app.get(url, auth=self.auth_one)
+        res = self.app.get(url, auth=self.basic_auth_one)
         node_json = res.json['data']
 
         ids = [each['id'] for each in node_json]
@@ -242,7 +235,7 @@ class TestNodeFiltering(ApiTestCase):
     def test_alternate_filtering_field_logged_in(self):
         url = "/v2/nodes/?filter[description]=Three"
 
-        res = self.app.get(url, auth=self.auth_one)
+        res = self.app.get(url, auth=self.basic_auth_one)
         node_json = res.json['data']
 
         ids = [each['id'] for each in node_json]
@@ -273,7 +266,7 @@ class TestNodeFiltering(ApiTestCase):
         # TODO Change to check for error when the functionality changes. Currently acts as though it doesn't exist
         url = "/v2/nodes/?filter[notafield]=bogus"
 
-        res = self.app.get(url, auth=self.auth_one)
+        res = self.app.get(url, auth=self.basic_auth_one)
         node_json = res.json['data']
 
         ids = [each['id'] for each in node_json]
@@ -308,7 +301,7 @@ class TestNodeCreate(ApiTestCase):
         self.user = UserFactory.build()
         self.user.set_password('justapoorboy')
         self.user.save()
-        self.auth = (self.user.username, 'justapoorboy')
+        self.basic_auth = (self.user.username, 'justapoorboy')
 
         self.url = '/v2/nodes/'
 
@@ -319,7 +312,7 @@ class TestNodeCreate(ApiTestCase):
         self.user_two = UserFactory.build()
         self.user_two.set_password('justapoorboy')
         self.user_two.save()
-        self.auth_two = (self.user_two.username, 'justapoorboy')
+        self.basic_auth_two = (self.user_two.username, 'justapoorboy')
 
         self.public_project = {'title': self.title, 'description': self.description, 'category' : self.category,
                           'public': True }
@@ -331,7 +324,7 @@ class TestNodeCreate(ApiTestCase):
         assert_equal(res.status_code, 401)
 
     def test_creates_public_project_logged_in(self):
-        res = self.app.post_json(self.url, self.public_project, auth=self.auth)
+        res = self.app.post_json(self.url, self.public_project, auth=self.basic_auth)
         assert_equal(res.status_code, 201)
         assert_equal(res.json['data']['title'], self.public_project['title'])
         assert_equal(res.json['data']['description'], self.public_project['description'])
@@ -342,7 +335,7 @@ class TestNodeCreate(ApiTestCase):
         assert_equal(res.status_code, 401)
 
     def test_creates_private_project_logged_in_contributor(self):
-        res = self.app.post_json(self.url, self.private_project, auth=self.auth)
+        res = self.app.post_json(self.url, self.private_project, auth=self.basic_auth)
         assert_equal(res.status_code, 201)
         assert_equal(res.json['data']['title'], self.private_project['title'])
         assert_equal(res.json['data']['description'], self.private_project['description'])
@@ -357,11 +350,11 @@ class TestNodeCreate(ApiTestCase):
             'description': description,
             'category': self.category,
             'public': True,
-        }, auth=self.auth)
+        }, auth=self.basic_auth)
         project_id = res.json['data']['id']
         assert_equal(res.status_code, 201)
         url = '/v2/nodes/{}/'.format(project_id)
-        res = self.app.get(url, auth=self.auth)
+        res = self.app.get(url, auth=self.basic_auth)
         assert_equal(res.json['data']['title'], strip_html(title))
         assert_equal(res.json['data']['description'], strip_html(description))
         assert_equal(res.json['data']['category'], self.category)
@@ -372,12 +365,12 @@ class TestNodeDetail(ApiTestCase):
         self.user = UserFactory.build()
         self.user.set_password('justapoorboy')
         self.user.save()
-        self.auth = (self.user.username, 'justapoorboy')
+        self.basic_auth = (self.user.username, 'justapoorboy')
 
         self.user_two = UserFactory.build()
         self.user_two.set_password('justapoorboy')
         self.user_two.save()
-        self.auth_two = (self.user_two.username, 'justapoorboy')
+        self.basic_auth_two = (self.user_two.username, 'justapoorboy')
 
         self.public_project = ProjectFactory(title="Project One", is_public=True, creator=self.user)
         self.private_project = ProjectFactory(title="Project Two", is_public=False, creator=self.user)
@@ -392,7 +385,7 @@ class TestNodeDetail(ApiTestCase):
         assert_equal(res.json['data']['category'], self.public_project.category)
 
     def test_return_public_project_details_logged_in(self):
-        res = self.app.get(self.public_url, auth=self.auth)
+        res = self.app.get(self.public_url, auth=self.basic_auth)
         assert_equal(res.status_code, 200)
         assert_equal(res.json['data']['title'], self.public_project.title)
         assert_equal(res.json['data']['description'], self.public_project.description)
@@ -403,14 +396,14 @@ class TestNodeDetail(ApiTestCase):
         assert_equal(res.status_code, 401)
 
     def test_return_private_project_details_logged_in_contributor(self):
-        res = self.app.get(self.private_url, auth=self.auth)
+        res = self.app.get(self.private_url, auth=self.basic_auth)
         assert_equal(res.status_code, 200)
         assert_equal(res.json['data']['title'], self.private_project.title)
         assert_equal(res.json['data']['description'], self.private_project.description)
         assert_equal(res.json['data']['category'], self.private_project.category)
 
     def test_return_private_project_details_logged_in_non_contributor(self):
-        res = self.app.get(self.private_url, auth=self.auth_two, expect_errors=True)
+        res = self.app.get(self.private_url, auth=self.basic_auth_two, expect_errors=True)
         assert_equal(res.status_code, 403)
 
 
@@ -421,7 +414,7 @@ class TestNodeUpdate(ApiTestCase):
         self.user = UserFactory.build()
         self.user.set_password('justapoorboy')
         self.user.save()
-        self.auth = (self.user.username, 'justapoorboy')
+        self.basic_auth = (self.user.username, 'justapoorboy')
 
         self.title = 'Cool Project'
         self.new_title = 'Super Cool Project'
@@ -433,7 +426,7 @@ class TestNodeUpdate(ApiTestCase):
         self.user_two = UserFactory.build()
         self.user_two.set_password('justapoorboy')
         self.user_two.save()
-        self.auth_two = (self.user_two.username, 'justapoorboy')
+        self.basic_auth_two = (self.user_two.username, 'justapoorboy')
 
         self.public_project = ProjectFactory(title=self.title, description=self.description, category=self.category, is_public=True, creator=self.user)
         self.public_url = '/v2/nodes/{}/'.format(self.public_project._id)
@@ -457,7 +450,7 @@ class TestNodeUpdate(ApiTestCase):
             'description': self.new_description,
             'category': self.new_category,
             'public': True,
-        }, auth=self.auth)
+        }, auth=self.basic_auth)
         assert_equal(res.status_code, 200)
         assert_equal(res.json['data']['title'], self.new_title)
         assert_equal(res.json['data']['description'], self.new_description)
@@ -469,7 +462,7 @@ class TestNodeUpdate(ApiTestCase):
             'description': self.new_description,
             'category': self.new_category,
             'public': True,
-        }, auth=self.auth_two, expect_errors=True)
+        }, auth=self.basic_auth_two, expect_errors=True)
         assert_equal(res.status_code, 403)
 
     def test_update_private_project_logged_out(self):
@@ -487,7 +480,7 @@ class TestNodeUpdate(ApiTestCase):
             'description': self.new_description,
             'category': self.new_category,
             'public': False,
-        }, auth=self.auth)
+        }, auth=self.basic_auth)
         assert_equal(res.status_code, 200)
         assert_equal(res.json['data']['title'], self.new_title)
         assert_equal(res.json['data']['description'], self.new_description)
@@ -499,7 +492,7 @@ class TestNodeUpdate(ApiTestCase):
             'description': self.new_description,
             'category': self.new_category,
             'public': False,
-        }, auth=self.auth_two, expect_errors=True)
+        }, auth=self.basic_auth_two, expect_errors=True)
         assert_equal(res.status_code, 403)
 
     def test_update_project_sanitizes_html_properly(self):
@@ -515,7 +508,7 @@ class TestNodeUpdate(ApiTestCase):
             'description': new_description,
             'category': self.new_category,
             'public': True,
-        }, auth=self.auth)
+        }, auth=self.basic_auth)
         assert_equal(res.status_code, 200)
         assert_equal(res.json['data']['title'], strip_html(new_title))
         assert_equal(res.json['data']['description'], strip_html(new_description))
@@ -528,7 +521,7 @@ class TestNodeUpdate(ApiTestCase):
         url = '/v2/nodes/{}/'.format(project._id)
         res = self.app.patch_json(url, {
             'title': new_title,
-        }, auth=self.auth)
+        }, auth=self.basic_auth)
         assert_equal(res.status_code, 200)
         res = self.app.get(url)
         assert_equal(res.status_code, 200)
@@ -546,12 +539,12 @@ class TestNodeUpdate(ApiTestCase):
         url = '/v2/nodes/{}/'.format(project._id)
         res = self.app.patch_json(url, {
             'is_public': False,
-        }, auth=self.auth_two, expect_errors=True)
+        }, auth=self.basic_auth_two, expect_errors=True)
         assert_equal(res.status_code, 403)
         # Test creator writing to public field (supposed to be read-only)
         res = self.app.patch_json(url, {
             'is_public': False,
-        }, auth=self.auth, expect_errors=True)
+        }, auth=self.basic_auth, expect_errors=True)
         assert_equal(res.status_code, 403)
 
     def test_partial_update_public_project_logged_out(self):
@@ -561,7 +554,7 @@ class TestNodeUpdate(ApiTestCase):
     def test_partial_update_public_project_logged_in(self):
         res = self.app.patch_json(self.public_url, {
             'title': self.new_title,
-        }, auth=self.auth)
+        }, auth=self.basic_auth)
         assert_equal(res.status_code, 200)
         assert_equal(res.json['data']['title'], self.new_title)
         assert_equal(res.json['data']['description'], self.description)
@@ -570,7 +563,7 @@ class TestNodeUpdate(ApiTestCase):
         # Public resource, logged in, unauthorized
         res = self.app.patch_json(self.public_url, {
             'title': self.new_title,
-        }, auth=self.auth_two, expect_errors=True)
+        }, auth=self.basic_auth_two, expect_errors=True)
         assert_equal(res.status_code, 403)
 
     def test_partial_update_private_project_logged_out(self):
@@ -578,14 +571,14 @@ class TestNodeUpdate(ApiTestCase):
         assert_equal(res.status_code, 401)
 
     def test_partial_update_private_project_logged_in_contributor(self):
-        res = self.app.patch_json(self.private_url, {'title': self.new_title}, auth=self.auth)
+        res = self.app.patch_json(self.private_url, {'title': self.new_title}, auth=self.basic_auth)
         assert_equal(res.status_code, 200)
         assert_equal(res.json['data']['title'], self.new_title)
         assert_equal(res.json['data']['description'], self.description)
         assert_equal(res.json['data']['category'], self.category)
 
     def test_partial_update_private_project_logged_in_non_contributor(self):
-        res = self.app.patch_json(self.private_url, {'title': self.new_title}, auth=self.auth_two, expect_errors=True)
+        res = self.app.patch_json(self.private_url, {'title': self.new_title}, auth=self.basic_auth_two, expect_errors=True)
         assert_equal(res.status_code, 403)
 
 class TestNodeContributorList(ApiTestCase):
@@ -597,12 +590,12 @@ class TestNodeContributorList(ApiTestCase):
         self.password = password
         self.user.set_password(password)
         self.user.save()
-        self.auth = (self.user.username, password)
+        self.basic_auth = (self.user.username, password)
 
         self.user_two = UserFactory.build()
         self.user_two.set_password(self.password)
         self.user_two.save()
-        self.auth_two = (self.user_two.username, self.password)
+        self.basic_auth_two = (self.user_two.username, self.password)
 
         self.private_project = ProjectFactory(is_public=False, creator=self.user)
         self.private_url = '/v2/nodes/{}/contributors/'.format(self.private_project._id)
@@ -618,7 +611,7 @@ class TestNodeContributorList(ApiTestCase):
         assert_equal(res.json['data'][1]['id'], self.user_two._id)
 
     def test_return_public_contributor_list_logged_in(self):
-         res = self.app.get(self.public_url, auth=self.auth_two)
+         res = self.app.get(self.public_url, auth=self.basic_auth_two)
          assert_equal(res.status_code, 200)
          assert_equal(len(res.json['data']), 1)
          assert_equal(res.json['data'][0]['id'], self.user._id)
@@ -629,14 +622,14 @@ class TestNodeContributorList(ApiTestCase):
 
     def test_return_private_contributor_list_logged_in_contributor(self):
         self.private_project.add_contributor(self.user_two)
-        res = self.app.get(self.private_url, auth=self.auth)
+        res = self.app.get(self.private_url, auth=self.basic_auth)
         assert_equal(res.status_code, 200)
         assert_equal(len(res.json['data']), 2)
         assert_equal(res.json['data'][0]['id'], self.user._id)
         assert_equal(res.json['data'][1]['id'], self.user_two._id)
 
     def test_return_private_contributor_list_logged_in_non_contributor(self):
-         res = self.app.get(self.private_url, auth=self.auth_two, expect_errors=True)
+         res = self.app.get(self.private_url, auth=self.basic_auth_two, expect_errors=True)
          assert_equal(res.status_code, 403)
 
 class TestNodeContributorFiltering(ApiTestCase):
@@ -647,24 +640,24 @@ class TestNodeContributorFiltering(ApiTestCase):
         self.password = fake.password()
         self.project.creator.set_password(self.password)
         self.project.creator.save()
-        self.auth = (self.project.creator.username, self.password)
+        self.basic_auth = (self.project.creator.username, self.password)
 
     def test_filtering_node_with_only_bibliographic_contributors(self):
 
         base_url = '/v2/nodes/{}/contributors/'.format(self.project._id)
         # no filter
-        res = self.app.get(base_url, auth=self.auth)
+        res = self.app.get(base_url, auth=self.basic_auth)
         assert_equal(len(res.json['data']), 1)
 
         # filter for bibliographic contributors
         url = base_url + '?filter[bibliographic]=True'
-        res = self.app.get(url, auth=self.auth)
+        res = self.app.get(url, auth=self.basic_auth)
         assert_equal(len(res.json['data']), 1)
         assert_true(res.json['data'][0].get('bibliographic', None))
 
         # filter for non-bibliographic contributors
         url = base_url + '?filter[bibliographic]=False'
-        res = self.app.get(url, auth=self.auth)
+        res = self.app.get(url, auth=self.basic_auth)
         assert_equal(len(res.json['data']), 0)
 
     def test_filtering_node_with_non_bibliographic_contributor(self):
@@ -675,18 +668,18 @@ class TestNodeContributorFiltering(ApiTestCase):
         base_url = base_url = '/v2/nodes/{}/contributors/'.format(self.project._id)
 
         # no filter
-        res = self.app.get(base_url, auth=self.auth)
+        res = self.app.get(base_url, auth=self.basic_auth)
         assert_equal(len(res.json['data']), 2)
 
         # filter for bibliographic contributors
         url = base_url + '?filter[bibliographic]=True'
-        res = self.app.get(url, auth=self.auth)
+        res = self.app.get(url, auth=self.basic_auth)
         assert_equal(len(res.json['data']), 1)
         assert_true(res.json['data'][0].get('bibliographic', None))
 
         # filter for non-bibliographic contributors
         url = base_url + '?filter[bibliographic]=False'
-        res = self.app.get(url, auth=self.auth)
+        res = self.app.get(url, auth=self.basic_auth)
         assert_equal(len(res.json['data']), 1)
         assert_false(res.json['data'][0].get('bibliographic', None))
 
@@ -698,7 +691,7 @@ class TestNodeRegistrationList(ApiTestCase):
         self.password = password
         self.user.set_password(password)
         self.user.save()
-        self.auth = (self.user.username, password)
+        self.basic_auth = (self.user.username, password)
         self.project = ProjectFactory(is_public=False, creator=self.user)
         self.registration_project = RegistrationFactory(creator=self.user, project=self.project)
         self.project.save()
@@ -712,7 +705,7 @@ class TestNodeRegistrationList(ApiTestCase):
         self.user_two = UserFactory.build()
         self.user_two.set_password(password)
         self.user_two.save()
-        self.auth_two = (self.user_two.username, password)
+        self.basic_auth_two = (self.user_two.username, password)
 
     def test_return_public_registrations_logged_out(self):
         res = self.app.get(self.public_url)
@@ -720,7 +713,7 @@ class TestNodeRegistrationList(ApiTestCase):
         assert_equal(res.json['data'][0]['title'], self.public_project.title)
 
     def test_return_public_registrations_logged_in(self):
-        res = self.app.get(self.public_url, auth=self.auth)
+        res = self.app.get(self.public_url, auth=self.basic_auth)
         assert_equal(res.status_code, 200)
         assert_equal(res.json['data'][0]['category'], self.public_project.category)
 
@@ -729,12 +722,12 @@ class TestNodeRegistrationList(ApiTestCase):
         assert_equal(res.status_code, 401)
 
     def test_return_private_registrations_logged_in_contributor(self):
-        res = self.app.get(self.private_url, auth=self.auth)
+        res = self.app.get(self.private_url, auth=self.basic_auth)
         assert_equal(res.status_code, 200)
         assert_equal(res.json['data'][0]['category'], self.project.category)
 
     def test_return_private_registrations_logged_in_non_contributor(self):
-        res = self.app.get(self.private_url, auth=self.auth_two, expect_errors=True)
+        res = self.app.get(self.private_url, auth=self.basic_auth_two, expect_errors=True)
         assert_equal(res.status_code, 403)
 
 class TestNodeChildrenList(ApiTestCase):
@@ -745,7 +738,7 @@ class TestNodeChildrenList(ApiTestCase):
         self.password = password
         self.user.set_password(password)
         self.user.save()
-        self.auth = (self.user.username, password)
+        self.basic_auth = (self.user.username, password)
         self.project = ProjectFactory()
         self.project.add_contributor(self.user, permissions=['read', 'write'])
         self.project.save()
@@ -762,10 +755,10 @@ class TestNodeChildrenList(ApiTestCase):
         self.user_two = UserFactory.build()
         self.user_two.set_password(password)
         self.user_two.save()
-        self.auth_two = (self.user_two.username, password)
+        self.basic_auth_two = (self.user_two.username, password)
 
     def test_node_children_list_does_not_include_pointers(self):
-        res = self.app.get(self.private_project_url, auth=self.auth)
+        res = self.app.get(self.private_project_url, auth=self.basic_auth)
         assert_equal(len(res.json['data']), 1)
 
     def test_return_public_node_children_list_logged_out(self):
@@ -775,7 +768,7 @@ class TestNodeChildrenList(ApiTestCase):
         assert_equal(res.json['data'][0]['id'], self.public_component._id)
 
     def test_return_public_node_children_list_logged_in(self):
-        res = self.app.get(self.public_project_url, auth=self.auth_two)
+        res = self.app.get(self.public_project_url, auth=self.basic_auth_two)
         assert_equal(res.status_code, 200)
         assert_equal(len(res.json['data']), 1)
         assert_equal(res.json['data'][0]['id'], self.public_component._id)
@@ -785,18 +778,18 @@ class TestNodeChildrenList(ApiTestCase):
         assert_equal(res.status_code, 401)
 
     def test_return_private_node_children_list_logged_in_contributor(self):
-        res = self.app.get(self.private_project_url, auth=self.auth)
+        res = self.app.get(self.private_project_url, auth=self.basic_auth)
         assert_equal(res.status_code, 200)
         assert_equal(len(res.json['data']), 1)
         assert_equal(res.json['data'][0]['id'], self.component._id)
 
     def test_return_private_node_children_list_logged_in_non_contributor(self):
-        res = self.app.get(self.private_project_url, auth=self.auth_two, expect_errors=True)
+        res = self.app.get(self.private_project_url, auth=self.basic_auth_two, expect_errors=True)
         assert_equal(res.status_code, 403)
 
     def test_node_children_list_does_not_include_unauthorized_projects(self):
         private_component = NodeFactory(parent=self.project)
-        res = self.app.get(self.private_project_url, auth=self.auth)
+        res = self.app.get(self.private_project_url, auth=self.basic_auth)
         assert_equal(len(res.json['data']), 1)
 
         Node.remove()
@@ -808,7 +801,7 @@ class TestNodePointersList(ApiTestCase):
         self.user = UserFactory.build()
         self.user.set_password('password')
         self.user.save()
-        self.auth = (self.user.username, 'password')
+        self.basic_auth = (self.user.username, 'password')
         self.project = ProjectFactory(is_public=False, creator=self.user)
         self.pointer_project = ProjectFactory(is_public=False, creator=self.user)
         self.project.add_pointer(self.pointer_project, auth=Auth(self.user))
@@ -822,7 +815,7 @@ class TestNodePointersList(ApiTestCase):
         self.user_two = UserFactory.build()
         self.user_two.set_password('password')
         self.user_two.save()
-        self.auth_two = (self.user_two.username, 'password')
+        self.basic_auth_two = (self.user_two.username, 'password')
 
     def test_return_public_node_pointers_logged_out(self):
         res = self.app.get(self.public_url)
@@ -832,7 +825,7 @@ class TestNodePointersList(ApiTestCase):
         assert_in(res_json[0]['node_id'], self.public_pointer_project._id)
 
     def test_return_public_node_pointers_logged_in(self):
-        res = self.app.get(self.public_url, auth=self.auth_two)
+        res = self.app.get(self.public_url, auth=self.basic_auth_two)
         res_json = res.json['data']
         assert_equal(len(res_json), 1)
         assert_equal(res.status_code, 200)
@@ -843,14 +836,14 @@ class TestNodePointersList(ApiTestCase):
         assert_equal(res.status_code, 401)
 
     def test_return_private_node_pointers_logged_in_contributor(self):
-        res = self.app.get(self.private_url, auth=self.auth)
+        res = self.app.get(self.private_url, auth=self.basic_auth)
         res_json = res.json['data']
         assert_equal(res.status_code, 200)
         assert_equal(len(res_json), 1)
         assert_in(res_json[0]['node_id'], self.pointer_project._id)
 
     def test_return_private_node_pointers_logged_in_non_contributor(self):
-        res = self.app.get(self.private_url, auth=self.auth_two, expect_errors=True)
+        res = self.app.get(self.private_url, auth=self.basic_auth_two, expect_errors=True)
         assert_equal(res.status_code, 403)
 
 class TestCreateNodePointer(ApiTestCase):
@@ -859,7 +852,7 @@ class TestCreateNodePointer(ApiTestCase):
         self.user = UserFactory.build()
         self.user.set_password('password')
         self.user.save()
-        self.auth = (self.user.username, 'password')
+        self.basic_auth = (self.user.username, 'password')
         self.project = ProjectFactory(is_public=False, creator=self.user)
         self.pointer_project = ProjectFactory(is_public=False, creator=self.user)
         self.project.add_pointer(self.pointer_project, auth=Auth(self.user))
@@ -875,17 +868,17 @@ class TestCreateNodePointer(ApiTestCase):
         self.user_two = UserFactory.build()
         self.user_two.set_password('password')
         self.user_two.save()
-        self.auth_two = (self.user_two.username, 'password')
+        self.basic_auth_two = (self.user_two.username, 'password')
 
     def test_creates_public_node_pointer_logged_out(self):
         res = self.app.post(self.public_url, self.public_payload, expect_errors = True)
         assert_equal(res.status_code, 401)
 
     def test_creates_public_node_pointer_logged_in(self):
-        res = self.app.post(self.public_url, self.public_payload, auth = self.auth_two, expect_errors=True)
+        res = self.app.post(self.public_url, self.public_payload, auth = self.basic_auth_two, expect_errors=True)
         assert_equal(res.status_code, 405)
 
-        res = self.app.post(self.public_url, self.public_payload, auth = self.auth, expect_errors=True)
+        res = self.app.post(self.public_url, self.public_payload, auth = self.basic_auth, expect_errors=True)
         assert_equal(res.status_code, 201)
         assert_equal(res.json['data']['node_id'], self.public_project._id)
 
@@ -894,12 +887,12 @@ class TestCreateNodePointer(ApiTestCase):
         assert_equal(res.status_code, 401)
 
     def test_creates_private_node_pointer_logged_in_contributor(self):
-        res = self.app.post(self.private_url, self.private_payload, auth=self.auth)
+        res = self.app.post(self.private_url, self.private_payload, auth=self.basic_auth)
         assert_equal(res.status_code, 201)
         assert_equal(res.json['data']['node_id'], self.project._id)
 
     def test_creates_private_node_pointer_logged_in_non_contributor(self):
-        res = self.app.post(self.private_url, self.private_payload, auth=self.auth_two, expect_errors=True)
+        res = self.app.post(self.private_url, self.private_payload, auth=self.basic_auth_two, expect_errors=True)
         assert_equal(res.status_code, 403)
 
 
@@ -910,14 +903,14 @@ class TestNodeFilesList(ApiTestCase):
         self.user = UserFactory.build()
         self.user.set_password('justapoorboy')
         self.user.save()
-        self.auth = (self.user.username, 'justapoorboy')
+        self.basic_auth = (self.user.username, 'justapoorboy')
         self.project = ProjectFactory(creator=self.user)
         self.private_url = url = '/v2/nodes/{}/files/'.format(self.project._id)
 
         self.user_two = UserFactory.build()
         self.user_two.set_password('justapoorboy')
         self.user_two.save()
-        self.auth_two = (self.user_two.username, 'justapoorboy')
+        self.basic_auth_two = (self.user_two.username, 'justapoorboy')
 
         self.public_project = ProjectFactory(creator=self.user, is_public=True)
         self.public_url = '/v2/nodes/{}/files/'.format(self.public_project._id)
@@ -928,7 +921,7 @@ class TestNodeFilesList(ApiTestCase):
         assert_equal(res.json['data'][0]['provider'], 'osfstorage')
 
     def test_returns_public_files_logged_in(self):
-        res = self.app.get(self.public_url, auth=self.auth)
+        res = self.app.get(self.public_url, auth=self.basic_auth)
         assert_equal(res.status_code, 200)
         assert_equal(res.json['data'][0]['provider'], 'osfstorage')
 
@@ -937,24 +930,24 @@ class TestNodeFilesList(ApiTestCase):
         assert_equal(res.status_code, 401)
 
     def test_returns_private_files_logged_in_contributor(self):
-        res = self.app.get(self.private_url, auth=self.auth)
+        res = self.app.get(self.private_url, auth=self.basic_auth)
         assert_equal(res.status_code, 200)
         assert_equal(len(res.json['data']), 1)
         assert_equal(res.json['data'][0]['provider'], 'osfstorage')
 
     def test_returns_private_files_logged_in_non_contributor(self):
-        res = self.app.get(self.private_url, auth=self.auth_two, expect_errors=True)
+        res = self.app.get(self.private_url, auth=self.basic_auth_two, expect_errors=True)
         assert_equal(res.status_code, 403)
 
     def test_returns_addon_folders(self):
         user_auth = Auth(self.user)
-        res = self.app.get(self.private_url, auth=self.auth)
+        res = self.app.get(self.private_url, auth=self.basic_auth)
         assert_equal(len(res.json['data']), 1)
         assert_equal(res.json['data'][0]['provider'], 'osfstorage')
 
         self.project.add_addon('github', auth=user_auth)
         self.project.save()
-        res = self.app.get(self.private_url, auth=self.auth)
+        res = self.app.get(self.private_url, auth=self.basic_auth)
         data = res.json['data']
         providers = [item['provider'] for item in data]
         assert_equal(len(data), 2)
@@ -979,7 +972,7 @@ class TestNodeFilesList(ApiTestCase):
         }
         mock_waterbutler_request.return_value = mock_res
         url = '/v2/nodes/{}/files/?path=%2F&provider=osfstorage'.format(self.project._id)
-        res = self.app.get(url, auth=self.auth)
+        res = self.app.get(url, auth=self.basic_auth)
         assert_equal(res.json['data'][0]['name'], 'NewFile')
         assert_equal(res.json['data'][0]['provider'], 'osfstorage')
 
@@ -989,7 +982,7 @@ class TestNodeFilesList(ApiTestCase):
         mock_res = mock.MagicMock()
         mock_res.status_code = 401
         mock_waterbutler_request.return_value = mock_res
-        res = self.app.get(url, auth=self.auth, expect_errors=True)
+        res = self.app.get(url, auth=self.basic_auth, expect_errors=True)
         assert_equal(res.status_code, 403)
 
     @mock.patch('api.nodes.views.requests.get')
@@ -999,7 +992,7 @@ class TestNodeFilesList(ApiTestCase):
         mock_res.status_code = 418
         mock_res.json.return_value = {}
         mock_waterbutler_request.return_value = mock_res
-        res = self.app.get(url, auth=self.auth, expect_errors=True)
+        res = self.app.get(url, auth=self.basic_auth, expect_errors=True)
         assert_equal(res.status_code, 400)
 
 class TestNodePointerDetail(ApiTestCase):
@@ -1009,7 +1002,7 @@ class TestNodePointerDetail(ApiTestCase):
         self.user = UserFactory.build()
         self.user.set_password('password')
         self.user.save()
-        self.auth = (self.user.username, 'password')
+        self.basic_auth = (self.user.username, 'password')
         self.project = ProjectFactory()
         self.pointer_project = ProjectFactory()
         self.pointer = self.project.add_pointer(self.pointer_project, auth=Auth(self.user), save=True)
@@ -1018,7 +1011,7 @@ class TestNodePointerDetail(ApiTestCase):
         self.user_two = UserFactory.build()
         self.user_two.set_password('password')
         self.user_two.save()
-        self.auth_two = (self.user_two.username, 'password')
+        self.basic_auth_two = (self.user_two.username, 'password')
 
         self.public_project = ProjectFactory(is_public=True)
         self.public_pointer_project = ProjectFactory(is_public=True)
@@ -1032,8 +1025,9 @@ class TestNodePointerDetail(ApiTestCase):
         assert_equal(res_json['node_id'], self.public_pointer_project._id)
 
     def test_returns_public_node_pointer_detail_logged_in(self):
-        res = self.app.get(self.public_url, auth=self.auth)
+        res = self.app.get(self.public_url, auth=self.basic_auth)
         res_json = res.json['data']
+        assert_equal(res.status_code, 200)
         assert_equal(res_json['node_id'], self.public_pointer_project._id)
 
     def test_returns_private_node_pointer_detail_logged_out(self):
@@ -1041,13 +1035,13 @@ class TestNodePointerDetail(ApiTestCase):
         assert_equal(res.status_code, 401)
 
     def test_returns_private_node_pointer_detail_logged_in_contributor(self):
-        res = self.app.get(self.private_url, auth=self.auth)
+        res = self.app.get(self.private_url, auth=self.basic_auth)
         res_json = res.json['data']
         assert_equal(res.status_code, 200)
         assert_equal(res_json['node_id'], self.pointer_project._id)
 
     def returns_private_node_pointer_detail_logged_in_non_contributor(self):
-        res = self.app.get(self.private_url, auth=self.auth_two, expect_errors=True)
+        res = self.app.get(self.private_url, auth=self.basic_auth_two, expect_errors=True)
         assert_equal(res.status_code, 403)
 
 class TestDeleteNodePointer(ApiTestCase):
@@ -1057,7 +1051,7 @@ class TestDeleteNodePointer(ApiTestCase):
         self.user = UserFactory.build()
         self.user.set_password('password')
         self.user.save()
-        self.auth = (self.user.username, 'password')
+        self.basic_auth = (self.user.username, 'password')
         self.project = ProjectFactory(creator=self.user, is_public=False)
         self.pointer_project = ProjectFactory(creator=self.user, is_public=True)
         self.pointer = self.project.add_pointer(self.pointer_project, auth=Auth(self.user), save=True)
@@ -1066,7 +1060,7 @@ class TestDeleteNodePointer(ApiTestCase):
         self.user_two = UserFactory.build()
         self.user_two.set_password('password')
         self.user_two.save()
-        self.auth_two = (self.user_two.username, 'password')
+        self.basic_auth_two = (self.user_two.username, 'password')
 
         self.public_project = ProjectFactory(is_public=True, creator=self.user)
         self.public_pointer_project = ProjectFactory(is_public=True, creator=self.user)
@@ -1078,10 +1072,10 @@ class TestDeleteNodePointer(ApiTestCase):
         assert_equal(res.status_code, 401)
 
     def test_deletes_public_node_pointer_logged_in(self):
-        res = self.app.delete(self.public_url, auth = self.auth_two, expect_errors=True)
+        res = self.app.delete(self.public_url, auth = self.basic_auth_two, expect_errors=True)
         assert_equal(res.status_code, 405)
 
-        res = self.app.delete(self.public_url, auth = self.auth, expect_errors=True)
+        res = self.app.delete(self.public_url, auth = self.basic_auth, expect_errors=True)
         assert_equal(res.status_code, 204)
         assert_equal(len(self.project.nodes_pointer), 0)
 
@@ -1090,16 +1084,16 @@ class TestDeleteNodePointer(ApiTestCase):
         assert_equal(res.status_code, 401)
 
     def test_deletes_private_node_pointer_logged_in_contributor(self):
-        res = self.app.delete(self.private_url, auth=self.auth)
+        res = self.app.delete(self.private_url, auth=self.basic_auth)
         assert_equal(res.status_code, 204)
         assert_equal(len(self.project.nodes_pointer), 0)
 
     def test_deletes_private_node_pointer_logged_in_non_contributor(self):
         url = '/v2/nodes/{}/pointers/'.format(self.project._id)
         payload = {'node_id': self.project._id}
-        res = self.app.post(url, payload, auth=self.auth)
+        res = self.app.post(url, payload, auth=self.basic_auth)
 
-        res = self.app.delete(url, auth=self.auth_two, expect_errors=True)
+        res = self.app.delete(url, auth=self.basic_auth_two, expect_errors=True)
         assert_equal(res.status_code, 405)
 
 

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -7,8 +7,32 @@ from website.models import Node
 from website.util.sanitize import strip_html
 
 from tests.base import ApiTestCase, fake
-from tests.factories import UserFactory, ProjectFactory, FolderFactory, DashboardFactory, NodeFactory, PointerFactory
+from tests.factories import UserFactory, ProjectFactory, FolderFactory, RegistrationFactory, DashboardFactory, NodeFactory, PointerFactory
 
+class TestWelcomeToApi(ApiTestCase):
+    def setUp(self):
+        ApiTestCase.setUp(self)
+        self.user = UserFactory.build()
+        self.user.set_password('justapoorboy')
+        self.user.save()
+        self.auth = (self.user.username, 'justapoorboy')
+
+    # Logged out, public page
+    def test_returns_200_for_logged_out_user(self):
+        res = self.app.get('/v2/')
+        assert_equal(res.status_code, 200)
+        assert_equal(res.json['meta']['current_user'], None)
+
+    # Logged in, public page
+    def test_returns_200_for_logged_in_user(self):
+        url = '/v2/'
+        res = self.app.get(url, auth=(self.auth))
+        assert_equal(res.status_code, 200)
+
+    def test_returns_current_user_info_when_logged_in(self):
+        url = '/v2/'
+        res = self.app.get(url, auth=(self.auth))
+        assert_equal(res.json['meta']['current_user']['data']['given_name'], 'Freddie')
 
 class TestNodeList(ApiTestCase):
 
@@ -32,9 +56,10 @@ class TestNodeList(ApiTestCase):
         node_json = res.json['data']
 
         ids = [each['id'] for each in node_json]
-
+        # Public resource, logged out
         assert_in(public._id, ids)
         assert_not_in(deleted._id, ids)
+        # Private resource, logged out
         assert_not_in(private._id, ids)
 
         Node.remove()
@@ -57,6 +82,10 @@ class TestNodeContributorList(ApiTestCase):
         self.project.add_contributor(self.user)
         self.project.save()
 
+        self.project_two = ProjectFactory(is_public=True)
+        self.project_two.add_contributor(self.user)
+        self.project_two.save()
+
     def test_must_be_contributor(self):
 
         non_contrib = UserFactory.build()
@@ -65,19 +94,28 @@ class TestNodeContributorList(ApiTestCase):
         non_contrib.save()
 
         url = '/v2/nodes/{}/contributors/'.format(self.project._id)
-        # non-authenticated
+        # non-authenticated, private resource
         res = self.app.get(url, expect_errors=True)
         assert_equal(res.status_code, 401)
 
-        # non-contrib
+        # non-contrib, private resource
         res = self.app.get(url, auth=(non_contrib.username, pw), expect_errors=True)
         assert_equal(res.status_code, 403)
 
-        # contrib
+        # contrib, private resource
         res = self.app.get(url, auth=(self.user.username, self.password))
         assert_equal(res.status_code, 200)
-        Node.remove()
 
+        url = '/v2/nodes/{}/contributors/'.format(self.project_two._id)
+        # Logged out, public
+        res = self.app.get(url)
+        assert_equal(res.status_code, 200)
+
+        # Logged in, public
+        res = self.app.get(url, auth=self.auth)
+        assert_equal(res.status_code, 200)
+
+        Node.remove()
 
 class TestNodeChildrenList(ApiTestCase):
     def setUp(self):
@@ -95,10 +133,23 @@ class TestNodeChildrenList(ApiTestCase):
         self.pointer = ProjectFactory()
         self.project.add_pointer(self.pointer, auth=Auth(self.user), save=True)
 
+        self.public_project = ProjectFactory(is_public=True)
+        self.public_project.save()
+        self.component = NodeFactory(parent=self.public_project, creator=self.user, is_public=True)
+
+        self.user_two = UserFactory.build()
+        self.user_two.set_password(password)
+        self.user_two.save()
+        self.auth_two = (self.user_two.username, password)
+
     def test_node_children_list_does_not_include_pointers(self):
         url = '/v2/nodes/{}/children/'.format(self.project._id)
+        # Private project, authorized
         res = self.app.get(url, auth=self.auth)
         assert_equal(len(res.json['data']), 1)
+        # Private resource, logged out
+        res = self.app.get(url, expect_errors=True)
+        assert_equal(res.status_code, 401)
 
     def test_node_children_list_does_not_include_unauthorized_projects(self):
         private_component = NodeFactory(parent=self.project)
@@ -106,6 +157,28 @@ class TestNodeChildrenList(ApiTestCase):
         res = self.app.get(url, auth=self.auth)
         assert_equal(len(res.json['data']), 1)
 
+        # Private project, unauthorized
+        res = self.app.get(url, auth=self.auth_two, expect_errors=True)
+        assert_equal(res.status_code, 403)
+
+    def test_public_node_children(self):
+        # Logged in, public resource
+        url = '/v2/nodes/{}/children/'.format(self.public_project._id)
+        res = self.app.get(url, auth=self.auth)
+        assert_equal(len(res.json['data']), 1)
+        assert_equal(res.status_code, 200)
+
+        # Logged in, public resource, non-contrib
+        res = self.app.get(url, auth=self.auth_two)
+        assert_equal(len(res.json['data']), 1)
+        assert_equal(res.status_code, 200)
+
+        # Logged out, public resource
+        res = self.app.get(url)
+        assert_equal(res.status_code, 200)
+        assert_equal(len(res.json['data']), 1)
+
+        Node.remove()
 
 class TestNodeFiltering(ApiTestCase):
 
@@ -138,10 +211,13 @@ class TestNodeFiltering(ApiTestCase):
         node_json = res.json['data']
 
         ids = [each['id'] for each in node_json]
+        # Public resource, logged in
         assert_in(self.project_one._id, ids)
         assert_in(self.project_two._id, ids)
         assert_in(self.project_three._id, ids)
+        # Private resource, authorized
         assert_in(self.private_project_user_one._id, ids)
+        # Private resource, unauthorized
         assert_not_in(self.private_project_user_two._id, ids)
         assert_not_in(self.folder._id, ids)
         assert_not_in(self.dashboard._id, ids)
@@ -151,11 +227,12 @@ class TestNodeFiltering(ApiTestCase):
 
         res = self.app.get(url)
         node_json = res.json['data']
-
+        # Public resource, logged out
         ids = [each['id'] for each in node_json]
         assert_in(self.project_one._id, ids)
         assert_in(self.project_two._id, ids)
         assert_in(self.project_three._id, ids)
+        # Private resource, logged out
         assert_not_in(self.private_project_user_one._id, ids)
         assert_not_in(self.private_project_user_two._id, ids)
         assert_not_in(self.folder._id, ids)
@@ -326,6 +403,15 @@ class TestNodePointersList(ApiTestCase):
         self.pointer_project = ProjectFactory()
         self.project.add_pointer(self.pointer_project, auth=Auth(self.user))
 
+        self.public_project = ProjectFactory(is_public=True)
+        self.public_pointer_project = ProjectFactory(is_public=True)
+        self.public_project.add_pointer(self.public_pointer_project, auth=Auth(self.user))
+
+        self.user_two = UserFactory.build()
+        self.user_two.set_password('password')
+        self.user_two.save()
+        self.auth_two = (self.user_two.username, 'password')
+
     def test_returns_200(self):
         url = '/v2/nodes/{}/pointers/'.format(self.project._id)
         res = self.app.get(url, auth=self.auth)
@@ -333,18 +419,64 @@ class TestNodePointersList(ApiTestCase):
 
     def test_returns_node_pointers(self):
         url = '/v2/nodes/{}/pointers/'.format(self.project._id)
+        # Logged in, private resource, authorized
         res = self.app.get(url, auth=self.auth)
         res_json = res.json['data']
         assert_equal(len(res_json), 1)
         assert_in(res_json[0]['node_id'], self.pointer_project._id)
 
+        url = '/v2/nodes/{}/pointers/'.format(self.project._id)
+
+        # Logged in, private resource, unauthorized
+        res = self.app.get(url, auth=self.auth_two, expect_errors=True)
+        assert_equal(res.status_code, 403)
+
+        # Logged out, private resource
+        res = self.app.get(url, expect_errors=True)
+        assert_equal(res.status_code, 401)
+
+    def test_return_public_node_pointers(self):
+        url ='/v2/nodes/{}/pointers/'.format(self.public_project._id)
+        # Logged in, public resource
+        res = self.app.get(url, auth=self.auth_two)
+        res_json = res.json['data']
+        assert_equal(len(res_json), 1)
+        assert_equal(res.status_code, 200)
+
+        # Logged out, public resource
+        res = self.app.get(url)
+        res_json = res.json['data']
+        assert_equal(len(res_json), 1)
+        assert_equal(res.status_code, 200)
+
     def test_creates_node_pointer(self):
         project = ProjectFactory()
         url = '/v2/nodes/{}/pointers/'.format(self.project._id)
         payload = {'node_id': project._id}
+
+        # Private, unauthorized
+        res = self.app.post(url, payload, auth=self.auth_two, expect_errors=True)
+        assert_equal(res.status_code, 403)
+
+        # Private, authorized
         res = self.app.post(url, payload, auth=self.auth)
         assert_equal(res.status_code, 201)
         assert_equal(res.json['data']['node_id'], project._id)
+
+        # Private, logged out
+        res = self.app.post(url, payload, expect_errors=True)
+        assert_equal(res.status_code, 401)
+
+        url = '/v2/nodes/{}/pointers/'.format(self.public_project._id)
+        payload = {'node_id': self.public_project._id}
+
+        # Public, logged in, non-contrib
+        res = self.app.post(url, payload, auth = self.auth_two, expect_errors=True)
+        assert_equal(res.status_code, 405)
+
+        # Public, logged out
+        res = self.app.post(url, payload, expect_errors = True)
+        assert_equal(res.status_code, 401)
 
 
 class TestNodeContributorFiltering(ApiTestCase):
@@ -360,7 +492,7 @@ class TestNodeContributorFiltering(ApiTestCase):
     def test_filtering_node_with_only_bibliographic_contributors(self):
 
         base_url = '/v2/nodes/{}/contributors/'.format(self.project._id)
-        # no filter
+        # no filter, private resource, logged in
         res = self.app.get(base_url, auth=self.auth)
         assert_equal(len(res.json['data']), 1)
 
@@ -411,6 +543,15 @@ class TestNodePointerDetail(ApiTestCase):
         self.pointer_project = ProjectFactory()
         self.pointer = self.project.add_pointer(self.pointer_project, auth=Auth(self.user), save=True)
 
+        self.user_two = UserFactory.build()
+        self.user_two.set_password('password')
+        self.user_two.save()
+        self.auth_two = (self.user_two.username, 'password')
+
+        self.public_project = ProjectFactory(is_public=True)
+        self.public_pointer_project = ProjectFactory(is_public=True)
+        self.public_pointer = self.public_project.add_pointer(self.public_pointer_project, auth= Auth(self.user), save=True)
+
     def test_returns_200(self):
         url = '/v2/nodes/{}/pointers/{}'.format(self.project._id, self.pointer._id)
         res = self.app.get(url, auth=self.auth)
@@ -418,15 +559,62 @@ class TestNodePointerDetail(ApiTestCase):
 
     def test_returns_node_pointer(self):
         url = '/v2/nodes/{}/pointers/{}'.format(self.project._id, self.pointer._id)
+        # Private resource, authorized
         res = self.app.get(url, auth=self.auth)
         res_json = res.json['data']
         assert_equal(res_json['node_id'], self.pointer_project._id)
 
+        # Private resource, logged out
+        res = self.app.get(url, expect_errors=True)
+        assert_equal(res.status_code, 401)
+
+        # Private resource, unauthorized
+        res = self.app.get(url, auth=self.auth_two, expect_errors=True)
+        assert_equal(res.status_code, 403)
+
+        url = '/v2/nodes/{}/pointers/{}'.format(self.public_project._id, self.public_pointer._id)
+
+        # Public resource, logged in
+        res = self.app.get(url, auth=self.auth)
+        res_json = res.json['data']
+        assert_equal(res_json['node_id'], self.public_pointer_project._id)
+
+        #Public resource, logged out
+        res = self.app.get(url)
+        assert_equal(res.status_code, 200)
+        res_json = res.json['data']
+        assert_equal(res_json['node_id'], self.public_pointer_project._id)
+
     def test_deletes_node_pointer(self):
         url = '/v2/nodes/{}/pointers/{}'.format(self.project._id, self.pointer._id)
+        # Private resource, authorized
         res = self.app.delete(url, auth=self.auth)
         assert_equal(res.status_code, 204)
         assert_equal(len(self.project.nodes_pointer), 0)
+
+        # Private resource, unauthorized
+        url = '/v2/nodes/{}/pointers/'.format(self.project._id)
+        payload = {'node_id': self.project._id}
+        res = self.app.post(url, payload, auth=self.auth)
+
+        res = self.app.delete(url, auth=self.auth_two, expect_errors=True)
+        assert_equal(res.status_code, 405)
+
+        # Private resource, logged out
+        res = self.app.delete(url, expect_errors=True)
+        assert_equal(res.status_code, 401)
+
+        url = '/v2/nodes/{}/pointers/'.format(self.public_project._id)
+        payload = {'node_id': self.public_project._id}
+        res = self.app.post(url, payload, auth=self.auth)
+
+        # Public resource, logged in
+        res = self.app.delete(url, auth = self.auth_two, expect_errors=True)
+        assert_equal(res.status_code, 405)
+
+        # Public resource, logged out
+        res = self.app.delete(url, expect_errors=True)
+        assert_equal(res.status_code, 401)
 
 
 class TestNodeFilesList(ApiTestCase):
@@ -438,6 +626,13 @@ class TestNodeFilesList(ApiTestCase):
         self.user.save()
         self.auth = (self.user.username, 'justapoorboy')
         self.project = ProjectFactory(creator=self.user)
+
+        self.user_two = UserFactory.build()
+        self.user_two.set_password('justapoorboy')
+        self.user_two.save()
+        self.auth_two = (self.user_two.username, 'justapoorboy')
+
+        self.public_project = ProjectFactory(creator=self.user)
 
     def test_returns_200(self):
         url = '/v2/nodes/{}/files/'.format(self.project._id)
@@ -454,13 +649,31 @@ class TestNodeFilesList(ApiTestCase):
 
         project.add_addon('github', auth=user_auth)
         project.save()
-
+        # Private resource, authorized
         res = self.app.get(url, auth=self.auth)
         data = res.json['data']
         providers = [item['provider'] for item in data]
         assert_equal(len(data), 2)
         assert_in('github', providers)
         assert_in('osfstorage', providers)
+
+        # Private resource, unauthorized
+        res = self.app.get(url, auth=self.auth_two, expect_errors=True)
+        assert_equal(res.status_code, 403)
+
+        # Private resource, logged out
+        res = self.app.get(url, expect_errors=True)
+        assert_equal(res.status_code, 401)
+
+        url = '/v2/nodes/{}/files/'.format(self.public_project._id)
+
+        # Public resource, logged in
+        res = self.app.get(url, auth=self.auth)
+        assert_equal(res.status_code, 200)
+
+        # Public resource, private components, logged out
+        res = self.app.get(url, expect_errors=True)
+        assert_equal(res.status_code, 401)
 
     @mock.patch('api.nodes.views.requests.get')
     def test_returns_node_files_list(self, mock_waterbutler_request):
@@ -519,8 +732,16 @@ class TestNodeCreateUpdate(ApiTestCase):
         self.new_description = 'An even cooler project'
         self.category = 'data'
         self.new_category = 'project'
+        self.user_two = UserFactory.build()
+        self.user_two.set_password('justapoorboy')
+        self.user_two.save()
+        self.auth_two = (self.user_two.username, 'justapoorboy')
+        self.project_one = ProjectFactory(title="Project One", is_public=True)
+        self.project_two = ProjectFactory(title="Project Two", is_public=False, creator=self.user)
+
 
     def test_creates_project_returns_proper_data(self):
+        # public project, logged in
         res = self.app.post_json(self.url, {
             'title': self.title,
             'description': self.description,
@@ -532,6 +753,28 @@ class TestNodeCreateUpdate(ApiTestCase):
         assert_equal(res.json['data']['title'], self.title)
         assert_equal(res.json['data']['description'], self.description)
         assert_equal(res.json['data']['category'], self.category)
+
+        private_project = {'title': 'Cool Private Project', 'description': 'A properly cool project', 'category': 'data',
+                           'public': False }
+        # Private project, logged in, authorized
+        res = self.app.post_json(self.url, private_project, auth=self.auth)
+        assert_equal(res.status_code, 201)
+        assert_equal(res.json['data']['title'], private_project['title'])
+        assert_equal(res.json['data']['description'], private_project['description'])
+        assert_equal(res.json['data']['category'], private_project['category'])
+
+    def test_cannot_create_node_when_logged_out(self):
+        url = '/v2/nodes/'
+        public_project = {'title': 'My public project', 'description': 'Project description', 'category' : 'project',
+                          'public': True }
+        private_project = {'title': 'My private project', 'description': 'Project description', 'category' : 'project',
+                          'public': False }
+        # Public resource, logged out
+        res1 = self.app.post_json(url, public_project, expect_errors=True)
+        assert_equal(res1.status_code, 401)
+        # Private resource, logged out
+        res2 = self.app.post_json(url, private_project, expect_errors=True)
+        assert_equal(res2.status_code, 401)
 
     def test_creates_project_creates_project(self):
         res = self.app.post_json(self.url, {
@@ -543,10 +786,31 @@ class TestNodeCreateUpdate(ApiTestCase):
         project_id = res.json['data']['id']
         assert_equal(res.status_code, 201)
         url = '/v2/nodes/{}/'.format(project_id)
+        # Public resource, logged in
         res = self.app.get(url, auth=self.auth)
         assert_equal(res.json['data']['title'], self.title)
         assert_equal(res.json['data']['description'], self.description)
         assert_equal(res.json['data']['category'], self.category)
+
+    def test_retrieve_project_details_when_logged_out(self):
+        # Public resource, logged out
+        url = '/v2/nodes/{}/'.format(self.project_one._id)
+        res = self.app.get(url)
+        assert_equal(res.status_code, 200)
+        # Private resource, logged out
+        url = '/v2/nodes/{}/'.format(self.project_two._id)
+        res = self.app.get(url, expect_errors=True)
+        assert_equal(res.status_code, 401)
+
+    def test_retrieve_private_project_when_logged_in(self):
+        # Private resource, authorized
+        url = '/v2/nodes/{}/'.format(self.project_two._id)
+        res = self.app.get(url, auth=self.auth)
+        assert_equal(res.status_code, 200)
+        # Private resource, unauthorized
+        res = self.app.get(url, auth=self.auth_two, expect_errors=True)
+        assert_equal(res.status_code, 403)
+
 
     def test_creates_project_creates_project_and_sanitizes_html(self):
         url = '/v2/nodes/'
@@ -568,6 +832,12 @@ class TestNodeCreateUpdate(ApiTestCase):
         assert_equal(res.json['data']['category'], self.category)
 
     def test_update_project_returns_proper_data(self):
+        title = 'Cool Project'
+        new_title = 'Super Cool Project'
+        description = 'A Properly Cool Project'
+        new_description = 'An even cooler project'
+        category = 'data'
+        new_category = 'project'
         project = self.project = ProjectFactory(
             title=self.title, description=self.description, category=self.category, is_public=True, creator=self.user)
 
@@ -578,10 +848,68 @@ class TestNodeCreateUpdate(ApiTestCase):
             'category': self.new_category,
             'public': True,
         }, auth=self.auth)
+        # Public project, logged in, contrib
         assert_equal(res.status_code, 200)
         assert_equal(res.json['data']['title'], self.new_title)
         assert_equal(res.json['data']['description'], self.new_description)
         assert_equal(res.json['data']['category'], self.new_category)
+
+        # Public project, logged in, unauthorized
+        res = self.app.put_json(url, {
+            'title': new_title,
+            'description': new_description,
+            'category': new_category,
+            'public': True,
+        }, auth=self.auth_two, expect_errors=True)
+        assert_equal(res.status_code, 403)
+
+    def test_update_project_while_logged_out(self):
+        new_title = 'Super Cool Project'
+        new_description = 'An even cooler project'
+        new_category = 'project'
+        url = '/v2/nodes/{}/'.format(self.project_one._id)
+        # Public resource, logged out
+        res = self.app.put_json(url, {
+            'title': new_title,
+            'description': new_description,
+            'category': new_category,
+            'public': True,
+        }, expect_errors=True)
+        assert_equal(res.status_code, 401)
+        # Private resource, logged out
+        url = '/v2/nodes/{}/'.format(self.project_two._id)
+        res = self.app.put_json(url, {
+            'title': new_title,
+            'description': new_description,
+            'category': new_category,
+            'public': False,
+        }, expect_errors=True)
+        assert_equal(res.status_code, 401)
+
+    def test_update_private_project_while_logged_in(self):
+        new_title = 'Super Cool Project'
+        new_description = 'An even cooler project'
+        new_category = 'project'
+        url = '/v2/nodes/{}/'.format(self.project_two._id)
+        # Private resource, authorized
+        res = self.app.put_json(url, {
+            'title': new_title,
+            'description': new_description,
+            'category': new_category,
+            'public': False,
+        }, auth=self.auth)
+        assert_equal(res.status_code, 200)
+
+        url = '/v2/nodes/{}/'.format(self.project_two._id)
+        # Private resource, unauthorized
+        res = self.app.put_json(url, {
+            'title': new_title,
+            'description': new_description,
+            'category': new_category,
+            'public': False,
+        }, auth=self.auth_two, expect_errors=True)
+        assert_equal(res.status_code, 403)
+
 
     def test_update_project_updates_project_properly(self):
         project = self.project = ProjectFactory(
@@ -620,9 +948,13 @@ class TestNodeCreateUpdate(ApiTestCase):
         assert_equal(res.json['data']['description'], strip_html(new_description))
 
     def test_partial_update_project_returns_proper_data(self):
+        title = 'Cool Project'
+        new_title = 'Super Cool Project'
+        description = 'A Properly Cool Project'
+        category = 'data'
         project = self.project = ProjectFactory(
             title=self.title, description=self.description, category=self.category, is_public=True, creator=self.user)
-
+        # Public resource, logged in
         url = '/v2/nodes/{}/'.format(project._id)
         res = self.app.patch_json(url, {
             'title': self.new_title,
@@ -631,6 +963,12 @@ class TestNodeCreateUpdate(ApiTestCase):
         assert_equal(res.json['data']['title'], self.new_title)
         assert_equal(res.json['data']['description'], self.description)
         assert_equal(res.json['data']['category'], self.category)
+
+        # Public resource, logged in, unauthorized
+        res = self.app.patch_json(url, {
+            'title': new_title,
+        }, auth=self.auth_two, expect_errors=True)
+        assert_equal(res.status_code, 403)
 
     def test_partial_update_project_updates_project_correctly_and_sanitizes_html(self):
         new_title = 'An <script>alert("even cooler")</script> project'
@@ -648,6 +986,45 @@ class TestNodeCreateUpdate(ApiTestCase):
         assert_equal(res.json['data']['description'], self.description)
         assert_equal(res.json['data']['category'], self.category)
 
+    def test_writing_to_public_field(self):
+        title = "Cool project"
+        description = 'A Properly Cool Project'
+        category = 'data'
+        project = self.project = ProjectFactory(
+            title=title, description=description, category=category, is_public=True, creator=self.user)
+        # Test non-contrib writing to public field
+        url = '/v2/nodes/{}/'.format(project._id)
+        res = self.app.patch_json(url, {
+            'is_public': False,
+        }, auth=self.auth_two, expect_errors=True)
+        assert_equal(res.status_code, 403)
+        # Test creator writing to public field
+        res = self.app.patch_json(url, {
+            'is_public': False,
+        }, auth=self.auth, expect_errors=True)
+        assert_equal(res.status_code, 403)
+
+    def test_partial_update_project_while_logged_out(self):
+        new_title = "Patching this title"
+        url = '/v2/nodes/{}/'.format(self.project_one._id)
+        # Public resource, logged out
+        res = self.app.patch_json(url, {'title': new_title}, expect_errors=True)
+        assert_equal(res.status_code, 401)
+        # Private resource, logged out
+        url = '/v2/nodes/{}/'.format(self.project_two._id)
+        res = self.app.patch_json(url, {'title': new_title}, expect_errors=True)
+        assert_equal(res.status_code, 401)
+
+    def test_partial_update_private_project_while_logged_in(self):
+        new_title = "Patching this title"
+        url = '/v2/nodes/{}/'.format(self.project_two._id)
+        # Private resource, authorized
+        res = self.app.patch_json(url, {'title': new_title}, auth=self.auth)
+        assert_equal(res.status_code, 200)
+        # Private resource, unauthorized
+        res = self.app.patch_json(url, {'title': new_title}, auth=self.auth_two, expect_errors=True)
+        assert_equal(res.status_code, 403)
+
     def test_partial_update_project_updates_project_properly(self):
         project = self.project = ProjectFactory(
             title=self.title, description=self.description, category=self.category, is_public=True, creator=self.user)
@@ -662,3 +1039,50 @@ class TestNodeCreateUpdate(ApiTestCase):
         assert_equal(res.json['data']['title'], self.title)
         assert_equal(res.json['data']['description'], self.new_description)
         assert_equal(res.json['data']['category'], self.category)
+
+class TestNodeRegistrationList(ApiTestCase):
+    def setUp(self):
+        ApiTestCase.setUp(self)
+        self.user = UserFactory.build()
+        password = fake.password()
+        self.password = password
+        self.user.set_password(password)
+        self.user.save()
+        self.auth = (self.user.username, password)
+        self.project = ProjectFactory(is_public=False, creator=self.user)
+        self.registration_project = RegistrationFactory(creator=self.user, project=self.project)
+
+        self.project.save()
+        self.public_project = ProjectFactory(is_public=True, creator=self.user)
+        self.public_registration_project = RegistrationFactory(creator=self.user, project=self.public_project)
+        self.public_project.save()
+
+
+        self.user_two = UserFactory.build()
+        self.user_two.set_password(password)
+        self.user_two.save()
+        self.auth_two = (self.user_two.username, password)
+
+    def test_public_registrations(self):
+        url = '/v2/nodes/{}/registrations/'.format(self.public_project._id)
+        # Public project, logged in
+        res = self.app.get(url, auth=self.auth)
+        assert_equal(res.status_code, 200)
+        assert_equal(res.json['data'][0]['category'], 'project')
+        # Public project, logged out
+        res = self.app.get(url)
+        assert_equal(res.status_code, 200)
+        assert_equal(res.json['data'][0]['title'], 'The meaning of life')
+
+    def test_private_registrations(self):
+        url = '/v2/nodes/{}/registrations/'.format(self.project._id)
+        #Private project, authorized
+        res = self.app.get(url, auth=self.auth)
+        assert_equal(res.status_code, 200)
+        assert_equal(res.json['data'][0]['category'], 'project')
+        # Private project, unauthorized
+        res = self.app.get(url, auth=self.auth_two, expect_errors=True)
+        assert_equal(res.status_code, 403)
+        # Private project, logged out
+        res = self.app.get(url, expect_errors=True)
+        assert_equal(res.status_code, 401)

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -16,22 +16,17 @@ class TestWelcomeToApi(ApiTestCase):
         self.user.set_password('justapoorboy')
         self.user.save()
         self.auth = (self.user.username, 'justapoorboy')
-        self.url = '/v2'
+        self.url = '/v2/'
 
-    # Logged out, public page
     def test_returns_200_for_logged_out_user(self):
         res = self.app.get(self.url)
         assert_equal(res.status_code, 200)
         assert_equal(res.json['meta']['current_user'], None)
 
-    # Logged in, public page
-    def test_returns_200_for_logged_in_user(self):
-        res = self.app.get(self.url, auth=(self.auth))
-        assert_equal(res.status_code, 200)
-
     def test_returns_current_user_info_when_logged_in(self):
-        res = self.app.get(self.url, auth=(self.auth))
-        assert_equal(res.json['meta']['current_user']['data']['given_name'], 'Freddie')
+        res = self.app.get(self.url, auth=self.auth)
+        assert_equal(res.status_code, 200)
+        assert_equal(res.json['meta']['current_user']['data']['given_name'], self.user.given_name)
 
 class TestNodeList(ApiTestCase):
 

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -1025,11 +1025,6 @@ class TestNodePointerDetail(ApiTestCase):
         self.public_pointer = self.public_project.add_pointer(self.public_pointer_project, auth= Auth(self.user), save=True)
         self.public_url = '/v2/nodes/{}/pointers/{}'.format(self.public_project._id, self.public_pointer._id)
 
-    def test_returns_200(self):
-        url = '/v2/nodes/{}/pointers/{}'.format(self.project._id, self.pointer._id)
-        res = self.app.get(url, auth=self.auth)
-        assert_equal(res.status_code, 200)
-
     def test_returns_public_node_pointer_detail_logged_out(self):
         res = self.app.get(self.public_url)
         assert_equal(res.status_code, 200)

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -29,7 +29,6 @@ class TestWelcomeToApi(ApiTestCase):
         assert_equal(res.json['meta']['current_user']['data']['given_name'], self.user.given_name)
 
 class TestNodeList(ApiTestCase):
-
     def setUp(self):
         ApiTestCase.setUp(self)
         self.user = UserFactory.build()
@@ -61,27 +60,27 @@ class TestNodeList(ApiTestCase):
         assert_not_in(self.deleted._id, ids)
         assert_not_in(self.private._id, ids)
 
-    def test_logged_out_user_can_access_public_node_list(self):
+    def test_return_public_node_list_logged_out_user(self):
         res = self.app.get(self.url)
         assert_equal(res.status_code, 200)
         ids = [each['id'] for each in res.json['data']]
         assert_in(self.public._id, ids)
         assert_not_in(self.private._id, ids)
 
-    def test_logged_in_user_can_access_public_node_list(self):
+    def test_return_public_node_list_logged_in_user(self):
         res = self.app.get(self.url, auth=self.non_contrib)
         assert_equal(res.status_code, 200)
         ids = [each['id'] for each in res.json['data']]
         assert_in(self.public._id, ids)
         assert_not_in(self.private._id, ids)
 
-    def test_logged_out_user_cannot_access_private_node_list(self):
+    def test_return_private_node_list_logged_out_user(self):
         res = self.app.get(self.url)
         ids = [each['id'] for each in res.json['data']]
         assert_in(self.public._id, ids)
         assert_not_in(self.private._id, ids)
 
-    def test_logged_in_contributor_can_access_private_node_list(self):
+    def test_return_private_node_list_logged_in_contributor(self):
         res = self.app.get(self.url, auth=self.auth)
         assert_equal(res.status_code, 200)
         assert_equal(len(res.json['data']), 2)
@@ -89,7 +88,7 @@ class TestNodeList(ApiTestCase):
         assert_in(self.public._id, ids)
         assert_in(self.private._id, ids)
 
-    def test_logged_in_non_contributor_cannot_access_private_node_list(self):
+    def test_return_private_node_list_logged_in_non_contributor(self):
         res = self.app.get(self.url, auth=self.non_contrib)
         ids = [each['id'] for each in res.json['data']]
         assert_in(self.public._id, ids)
@@ -310,17 +309,21 @@ class TestNodeCreate(ApiTestCase):
         self.user.set_password('justapoorboy')
         self.user.save()
         self.auth = (self.user.username, 'justapoorboy')
+
         self.url = '/v2/nodes/'
+
         self.title = 'Cool Project'
         self.new_title = 'Super Cool Project'
         self.description = 'A Properly Cool Project'
         self.new_description = 'An even cooler project'
         self.category = 'data'
         self.new_category = 'project'
+
         self.user_two = UserFactory.build()
         self.user_two.set_password('justapoorboy')
         self.user_two.save()
         self.auth_two = (self.user_two.username, 'justapoorboy')
+
         self.project_one = ProjectFactory(title="Project One", is_public=True, creator=self.user)
         self.project_two = ProjectFactory(title="Project Two", is_public=False, creator=self.user)
 

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -609,7 +609,7 @@ class TestNodeContributorList(ApiTestCase):
         self.public_project = ProjectFactory(is_public=True, creator=self.user)
         self.public_url = '/v2/nodes/{}/contributors/'.format(self.public_project._id)
 
-    def test_logged_out_user_can_access_public_contributor_list(self):
+    def test_return_public_contributor_list_logged_out(self):
         self.public_project.add_contributor(self.user_two)
         res = self.app.get(self.public_url)
         assert_equal(res.status_code, 200)
@@ -617,17 +617,17 @@ class TestNodeContributorList(ApiTestCase):
         assert_equal(res.json['data'][0]['id'], self.user._id)
         assert_equal(res.json['data'][1]['id'], self.user_two._id)
 
-    def test_logged_in_user_can_access_public_contributor_list(self):
+    def test_return_public_contributor_list_logged_in(self):
          res = self.app.get(self.public_url, auth=self.auth_two)
          assert_equal(res.status_code, 200)
          assert_equal(len(res.json['data']), 1)
          assert_equal(res.json['data'][0]['id'], self.user._id)
 
-    def test_logged_out_user_cannot_access_private_contributor_list(self):
+    def test_return_private_contributor_list_logged_out(self):
          res = self.app.get(self.private_url, expect_errors=True)
          assert_equal(res.status_code, 401)
 
-    def test_logged_in_contributor_can_access_private_contributor_list(self):
+    def test_return_private_contributor_list_logged_in_contributor(self):
         self.private_project.add_contributor(self.user_two)
         res = self.app.get(self.private_url, auth=self.auth)
         assert_equal(res.status_code, 200)
@@ -635,7 +635,7 @@ class TestNodeContributorList(ApiTestCase):
         assert_equal(res.json['data'][0]['id'], self.user._id)
         assert_equal(res.json['data'][1]['id'], self.user_two._id)
 
-    def test_logged_in_non_contributor_cannot_access_private_contributor_list(self):
+    def test_return_private_contributor_list_logged_in_non_contributor(self):
          res = self.app.get(self.private_url, auth=self.auth_two, expect_errors=True)
          assert_equal(res.status_code, 403)
 

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -813,13 +813,11 @@ class TestNodePointersList(ApiTestCase):
         self.pointer_project = ProjectFactory(is_public=False, creator=self.user)
         self.project.add_pointer(self.pointer_project, auth=Auth(self.user))
         self.private_url = '/v2/nodes/{}/pointers/'.format(self.project._id)
-        self.private_payload = {'node_id': self.project._id}
 
         self.public_project = ProjectFactory(is_public=True, creator=self.user)
         self.public_pointer_project = ProjectFactory(is_public=True, creator=self.user)
         self.public_project.add_pointer(self.public_pointer_project, auth=Auth(self.user))
         self.public_url = '/v2/nodes/{}/pointers/'.format(self.public_project._id)
-        self.public_payload = {'node_id': self.public_project._id}
 
         self.user_two = UserFactory.build()
         self.user_two.set_password('password')
@@ -840,27 +838,55 @@ class TestNodePointersList(ApiTestCase):
         assert_equal(res.status_code, 200)
         assert_in(res_json[0]['node_id'], self.public_pointer_project._id)
 
-    def test_cannot_return_private_node_pointers_logged_out(self):
+    def test_return_private_node_pointers_logged_out(self):
         res = self.app.get(self.private_url, expect_errors=True)
         assert_equal(res.status_code, 401)
 
     def test_return_private_node_pointers_logged_in_contributor(self):
         res = self.app.get(self.private_url, auth=self.auth)
         res_json = res.json['data']
+        assert_equal(res.status_code, 200)
         assert_equal(len(res_json), 1)
         assert_in(res_json[0]['node_id'], self.pointer_project._id)
 
-    def test_cannot_return_private_node_pointers_logged_in_non_contributor(self):
+    def test_return_private_node_pointers_logged_in_non_contributor(self):
         res = self.app.get(self.private_url, auth=self.auth_two, expect_errors=True)
         assert_equal(res.status_code, 403)
+
+class TestCreateNodePointer(ApiTestCase):
+    def setUp(self):
+        ApiTestCase.setUp(self)
+        self.user = UserFactory.build()
+        self.user.set_password('password')
+        self.user.save()
+        self.auth = (self.user.username, 'password')
+        self.project = ProjectFactory(is_public=False, creator=self.user)
+        self.pointer_project = ProjectFactory(is_public=False, creator=self.user)
+        self.project.add_pointer(self.pointer_project, auth=Auth(self.user))
+        self.private_url = '/v2/nodes/{}/pointers/'.format(self.project._id)
+        self.private_payload = {'node_id': self.project._id}
+
+        self.public_project = ProjectFactory(is_public=True, creator=self.user)
+        self.public_pointer_project = ProjectFactory(is_public=True, creator=self.user)
+        self.public_project.add_pointer(self.public_pointer_project, auth=Auth(self.user))
+        self.public_url = '/v2/nodes/{}/pointers/'.format(self.public_project._id)
+        self.public_payload = {'node_id': self.public_project._id}
+
+        self.user_two = UserFactory.build()
+        self.user_two.set_password('password')
+        self.user_two.save()
+        self.basic_auth_two = (self.user_two.username, 'password')
 
     def test_creates_public_node_pointer_logged_out(self):
         res = self.app.post(self.public_url, self.public_payload, expect_errors = True)
         assert_equal(res.status_code, 401)
 
     def test_creates_public_node_pointer_logged_in(self):
-        res = self.app.post(self.public_url, self.public_payload, auth = self.auth_two, expect_errors=True)
+        res = self.app.post(self.public_url, self.public_payload, auth = self.basic_auth_two, expect_errors=True)
         assert_equal(res.status_code, 405)
+
+        res = self.app.post(self.public_url, self.public_payload, auth = self.auth, expect_errors=True)
+        assert_equal(res.status_code, 200)
 
     def test_creates_private_node_pointer_logged_out(self):
         res = self.app.post(self.private_url, self.private_payload, expect_errors=True)
@@ -869,11 +895,12 @@ class TestNodePointersList(ApiTestCase):
     def test_creates_private_node_pointer_logged_in_contributor(self):
         res = self.app.post(self.private_url, self.private_payload, auth=self.auth)
         assert_equal(res.status_code, 201)
-        assert_equal(res.json['data']['node_id'], project._id)
+        assert_equal(res.json['data']['node_id'], self.project._id)
 
     def test_creates_private_node_pointer_logged_in_non_contributor(self):
-        res = self.app.post(self.private_url, self.private_payload, auth=self.auth_two, expect_errors=True)
-        assert_equal(res.status_code, 403)
+        res = self.app.post(self.private_url, self.private_payload, auth=self.basic_auth_two, expect_errors=True)
+        #assert_equal(res.status_code, 403)
+
 
 class TestNodeFilesList(ApiTestCase):
 

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -422,13 +422,14 @@ class TestNodeUpdate(ApiTestCase):
         self.user.set_password('justapoorboy')
         self.user.save()
         self.auth = (self.user.username, 'justapoorboy')
-        self.url = '/v2/nodes/'
+
         self.title = 'Cool Project'
         self.new_title = 'Super Cool Project'
         self.description = 'A Properly Cool Project'
         self.new_description = 'An even cooler project'
         self.category = 'data'
         self.new_category = 'project'
+
         self.user_two = UserFactory.build()
         self.user_two.set_password('justapoorboy')
         self.user_two.save()
@@ -436,6 +437,7 @@ class TestNodeUpdate(ApiTestCase):
 
         self.public_project = ProjectFactory(title=self.title, description=self.description, category=self.category, is_public=True, creator=self.user)
         self.public_url = '/v2/nodes/{}/'.format(self.public_project._id)
+
         self.private_project = ProjectFactory(title=self.title, description=self.description, category=self.category, is_public=False, creator=self.user)
         self.private_url ='/v2/nodes/{}/'.format(self.private_project._id)
 
@@ -518,7 +520,6 @@ class TestNodeUpdate(ApiTestCase):
         assert_equal(res.json['data']['title'], strip_html(new_title))
         assert_equal(res.json['data']['description'], strip_html(new_description))
 
-
     def test_partial_update_project_updates_project_correctly_and_sanitizes_html(self):
         new_title = 'An <script>alert("even cooler")</script> project'
         project = self.project = ProjectFactory(
@@ -547,11 +548,11 @@ class TestNodeUpdate(ApiTestCase):
             'is_public': False,
         }, auth=self.auth_two, expect_errors=True)
         assert_equal(res.status_code, 403)
-        # Test creator writing to public field
+        # Test creator writing to public field (supposed to be read-only)
         res = self.app.patch_json(url, {
             'is_public': False,
         }, auth=self.auth, expect_errors=True)
-        #assert_equal(res.status_code, 403)
+        assert_equal(res.status_code, 403)
 
     def test_partial_update_public_project_logged_out(self):
         res = self.app.patch_json(self.public_url, {'title': self.new_title}, expect_errors=True)
@@ -580,6 +581,8 @@ class TestNodeUpdate(ApiTestCase):
         res = self.app.patch_json(self.private_url, {'title': self.new_title}, auth=self.auth)
         assert_equal(res.status_code, 200)
         assert_equal(res.json['data']['title'], self.new_title)
+        assert_equal(res.json['data']['description'], self.description)
+        assert_equal(res.json['data']['category'], self.category)
 
     def test_partial_update_private_project_logged_in_non_contributor(self):
         res = self.app.patch_json(self.private_url, {'title': self.new_title}, auth=self.auth_two, expect_errors=True)
@@ -595,6 +598,8 @@ class TestNodeContributorList(ApiTestCase):
         self.user.set_password(password)
         self.user.save()
         self.auth = (self.user.username, password)
+
+        self.user_two 
         self.non_contrib = UserFactory.build()
         pw = fake.password()
         self.non_contrib.set_password(pw)


### PR DESCRIPTION
Add permission tests for: 

1	GET /v2/
2	GET /v2/nodes/ Projects and components
3	POST /v2/nodes/ Projects and components
4	GET /v2/nodes/{pk}/ Projects and component details
5	PUT /v2/nodes/{pk}/ Projects and component details
6	PATCH /v2/nodes/{pk}/ Projects and component details
7	GET /v2/nodes/{pk}/contributors/ Contributors (users) for a node
8	GET /v2/nodes/{pk}/registrations/ Registrations of the current node
9	GET /v2/nodes/{pk}/children/ Children of the current node
10	GET /v2/nodes/{pk}/pointers/ Pointers to other nodes
11	POST /v2/nodes/{pk}/pointers/ Pointers to other nodes
12	GET /v2/nodes/{pk}/files/ Files attached to a node
13	GET /v2/nodes/{pk}/pointers/{pointer_id} Detail of a pointer to another node
14	DELETE /v2/nodes/{pk}/pointers/{pointer_id} Detail of a pointer to another node