### PR TITLE
[feature][no, really] APIv2 URL helper functions

### DIFF
--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -118,8 +118,8 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'static/vendor')
 API_PATH = ''
 API_BASE = 'v2/'
 
-
-STATIC_URL = '{}/{}static/'.format(API_PATH, API_BASE)
+API_PREFIX = '{}/{}'.format(API_PATH, API_BASE)
+STATIC_URL = '{}static/'.format(API_PREFIX)
 
 STATICFILES_DIRS = (
     ('rest_framework_swagger/css', os.path.join(BASE_DIR, 'static/css')),

--- a/api/base/settings/local-dist.py
+++ b/api/base/settings/local-dist.py
@@ -2,4 +2,5 @@
 API_PATH = ''
 API_BASE = 'v2/'
 
-STATIC_URL = '{}/{}static/'.format(API_PATH, API_BASE)
+API_PREFIX = '{}/{}'.format(API_PATH, API_BASE)
+STATIC_URL = '{}static/'.format(API_PREFIX)

--- a/api/base/urls.py
+++ b/api/base/urls.py
@@ -11,9 +11,14 @@ base_pattern = '^{}'.format(API_BASE)
 
 urlpatterns = [
     ### API ###
-    url(base_pattern, include(patterns('',
-        url(r'^$', views.root),
-        url(r'^nodes/', include('api.nodes.urls', namespace='nodes')),
-        url(r'^users/', include('api.users.urls', namespace='users')),
-        url(r'^docs/', include('rest_framework_swagger.urls')),
-    )))] + static('/static/', document_root=settings.STATIC_ROOT)
+    url(base_pattern,
+        include(patterns('',
+                         url(r'^$', views.root),
+                         url(r'^nodes/', include('api.nodes.urls', namespace='nodes')),
+                         url(r'^users/', include('api.users.urls', namespace='users')),
+                         url(r'^docs/', include('rest_framework_swagger.urls')),
+                         ))
+        )
+]
+
+urlpatterns += static('/static/', document_root=settings.STATIC_ROOT)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -87,7 +87,7 @@ class TestUrlForHelpers(unittest.TestCase):
                               page_size=10)
         assert_equal(full_url, "https://staging2.osf.io/api/v2/nodes/abcd3/contributors/?filter%5Bfullname%5D=bob&page_size=10")
 
-    def test_api_v2_url_for_base_path(self):
+    def test_api_v2_url_base_path(self):
         """Given a blank string, should return the base path (domain + port + prefix) with no extra cruft at end"""
         full_url = api_v2_url('',
                               base_route='http://localhost:8000/',

--- a/website/routes.py
+++ b/website/routes.py
@@ -65,6 +65,8 @@ def get_globals():
         'language': language,
         'web_url_for': util.web_url_for,
         'api_url_for': util.api_url_for,
+        'api_v2_url': util.api_v2_url,  # URL function for templates
+        'api_v2_base': util.api_v2_url(''),  # Base url used by JS api helper
         'sanitize': sanitize,
         'js_str': lambda x: x.replace("'", r"\'").replace('"', r'\"'),
         'webpack_asset': paths.webpack_asset,

--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -46,8 +46,7 @@ var apiV2Url = function (pathString, paramsObject, apiPrefix){
     // Add parameters to URL (if any). Ensure encoding as necessary
     if (paramsObject){
         apiUrl += "?";
-        var paramString = $.param(paramsObject);
-        apiUrl += paramString;
+        apiUrl += $.param(paramsObject);
     }
     return apiUrl;
 };

--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -30,21 +30,26 @@ var growl = function(title, message, type) {
  *   apiV2Url("users/4urxt/applications", {"a":1, "filter[fullname]":"lawrence"}, "https://staging2.osf.io/api/v2/")
  * would yield the result:
  *  "https://staging2.osf.io/api/v2/users/4urxt/applications?a=1&filter%5Bfullname%5D=lawrence"
- *  @param {String} pathStr
- * @param {Object} paramsObj (optional) An object containing parameters to add to the URL. Otherwise pass 'undefined'.
+ * @param {String} pathString The string to be appended to the absolute base path, eg "users/4urxt"
+ * @param {Object} paramsObject (optional) An object containing parameters to add to the URL. Otherwise pass 'undefined'.
  * @param {String} apiPrefix (optional) Manually specify the prefix used for API routes (useful for testing)
  */
-var apiV2Url = function (pathStr, paramsObj, apiPrefix){
+var apiV2Url = function (pathString, paramsObject, apiPrefix){
     apiPrefix = apiPrefix || window.contextVars.apiV2Prefix;
 
-    var apiUrl = apiPrefix + pathStr;
+    // Don't output double slashes when concatenating two strings with adjoining slashes
+    if (apiPrefix && pathString && apiPrefix.charAt(apiPrefix.length - 1) === "/" && pathString.charAt(0) === "/"){
+        pathString = pathString.substring(1); // Strip off the redundant leading slash
+    }
+
+    var apiUrl = apiPrefix + pathString;
     // Add parameters to URL (if any). Ensure encoding as necessary
-    if (paramsObj){
+    if (paramsObject){
         apiUrl += "?";
         var paramArr = [];
-        for (var k in paramsObj){
-            if (paramsObj.hasOwnProperty(k)){
-                paramArr.push(encodeURIComponent(k) + "=" + encodeURIComponent(paramsObj[k]))
+        for (var k in paramsObject){
+            if (paramsObject.hasOwnProperty(k)){
+                paramArr.push(encodeURIComponent(k) + "=" + encodeURIComponent(paramsObject[k]))
             }
         }
         apiUrl += paramArr.join('&');

--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -561,6 +561,7 @@ module.exports = window.$.osf = {
     handleEditableError: handleEditableError,
     block: block,
     growl: growl,
+    apiV2Url: apiV2Url,
     unblock: unblock,
     joinPrompts: joinPrompts,
     mapByProperty: mapByProperty,

--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -46,13 +46,8 @@ var apiV2Url = function (pathString, paramsObject, apiPrefix){
     // Add parameters to URL (if any). Ensure encoding as necessary
     if (paramsObject){
         apiUrl += "?";
-        var paramArr = [];
-        for (var k in paramsObject){
-            if (paramsObject.hasOwnProperty(k)){
-                paramArr.push(encodeURIComponent(k) + "=" + encodeURIComponent(paramsObject[k]))
-            }
-        }
-        apiUrl += paramArr.join('&');
+        var paramString = $.param(paramsObject);
+        apiUrl += paramString;
     }
     return apiUrl;
 };

--- a/website/static/js/tests/osfHelpers.test.js
+++ b/website/static/js/tests/osfHelpers.test.js
@@ -24,6 +24,35 @@ describe('osfHelpers', () => {
         });
     });
 
+
+    describe('apiV2Url', () => {
+        it('returns correctly formatted URLs for described inputs', () => {
+            var fullUrl = $osf.apiV2Url('/nodes/abcd3/contributors/',
+                                         undefined,
+                                         'http://localhost:8000/v2/');
+            assert.equal(fullUrl, "http://localhost:8000/v2/nodes/abcd3/contributors/");
+
+            // No double slashes when apiPrefix and pathString have adjoining slashes
+            fullUrl = $osf.apiV2Url('nodes/abcd3/contributors/', undefined, 'http://localhost:8000/v2/');
+            assert.equal(fullUrl, "http://localhost:8000/v2/nodes/abcd3/contributors/");
+
+            // User is still responsible for the trailing slash. If they omit it, it doesn't appear at end of URL
+            fullUrl = $osf.apiV2Url('/nodes/abcd3/contributors', undefined, 'http://localhost:8000/v2/');
+            assert.notEqual(fullUrl, "http://localhost:8000/v2/nodes/abcd3/contributors/");
+
+            // Correctly handles- and encodes- URLs with parameters
+            fullUrl = $osf.apiV2Url('/nodes/abcd3/contributors/',
+                                  {'filter[fullname]': 'bob', 'page_size':10},
+                                  'https://staging2.osf.io/api/v2/');
+            assert.equal(fullUrl, "https://staging2.osf.io/api/v2/nodes/abcd3/contributors/?filter%5Bfullname%5D=bob&page_size=10");
+
+            // Given a blank string, should return the base path (domain + port + prefix) with no extra cruft at end
+            fullUrl = $osf.apiV2Url('', undefined, 'http://localhost:8000/v2/');
+            assert.equal(fullUrl, "http://localhost:8000/v2/");
+        });
+    });
+
+
     describe('handleJSONError', () => {
 
         var growlStub;

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -152,7 +152,8 @@
             % if access_token:
                 accessToken: '${access_token | js_str}',
             % endif
-                cookieName: '${cookie_name}'
+                cookieName: '${cookie_name}',
+                apiV2Prefix: '${api_v2_base | js_str }'
             });
         </script>
 

--- a/website/util/__init__.py
+++ b/website/util/__init__.py
@@ -7,9 +7,9 @@ import urlparse
 import furl
 
 from flask import request, url_for
-from django.core.urlresolvers import reverse
 
-from website import settings
+from website import settings as osf_settings
+from api.base import settings as drf_settings
 
 # Keep me: Makes rubeus importable from website.util
 from . import rubeus  # noqa
@@ -38,10 +38,6 @@ def _get_guid_url_for(url):
     guid_url = guid_url_profile_pattern.sub('', guid_url, count=1)
     return guid_url
 
-def api_v2_url_for(*args, **kwargs):
-    return reverse(prefix='/', *args, **kwargs)
-
-
 def api_url_for(view_name, _absolute=False, _offload=False, _xml=False, *args, **kwargs):
     """Reverse URL lookup for API routes (that use the JSONRenderer or XMLRenderer).
     Takes the same arguments as Flask's url_for, with the addition of
@@ -55,9 +51,35 @@ def api_url_for(view_name, _absolute=False, _offload=False, _xml=False, *args, *
     if _absolute:
         # We do NOT use the url_for's _external kwarg because app.config['SERVER_NAME'] alters
         # behavior in an unknown way (currently breaks tests). /sloria /jspies
-        domain = settings.OFFLOAD_DOMAIN if _offload else settings.DOMAIN
+        domain = osf_settings.OFFLOAD_DOMAIN if _offload else osf_settings.DOMAIN
         return urlparse.urljoin(domain, url)
     return url
+
+
+def api_v2_url(path_str,
+               params=None,
+               base_route=osf_settings.API_DOMAIN,
+               base_prefix=drf_settings.API_PREFIX,
+               **kwargs):
+    """
+    Convenience function for APIv2 usage: Concatenates parts of the absolute API url based on arguments provided
+
+    For example: given path_str = '/nodes/abcd3/contributors/' and params {'filter[fullname]': 'bob'},
+        this function would return the following on the local staging environment:
+        'http://localhost:8000/nodes/abcd3/contributors/?filter%5Bfullname%5D=bob'
+
+    This is NOT a full lookup function. It does not verify that a route actually exists to match the path_str given.
+    """
+    params = params or {}  # Optional params dict for special-character param names, eg filter[fullname]
+
+    base_url = furl.furl(base_route + base_prefix)
+    sub_url = furl.furl(path_str)
+
+    base_url.path.add(sub_url.path.segments)
+
+    base_url.args.update(params)
+    base_url.args.update(kwargs)
+    return str(base_url)
 
 
 def web_url_for(view_name, _absolute=False, _offload=False, _guid=False, *args, **kwargs):
@@ -73,7 +95,7 @@ def web_url_for(view_name, _absolute=False, _offload=False, _guid=False, *args, 
     if _absolute:
         # We do NOT use the url_for's _external kwarg because app.config['SERVER_NAME'] alters
         # behavior in an unknown way (currently breaks tests). /sloria /jspies
-        domain = settings.OFFLOAD_DOMAIN if _offload else settings.DOMAIN
+        domain = osf_settings.OFFLOAD_DOMAIN if _offload else osf_settings.DOMAIN
         return urlparse.urljoin(domain, url)
     return url
 
@@ -93,7 +115,7 @@ def waterbutler_url_for(route, provider, path, node, user=None, **query):
     :param User user: The user whos cookie will be used or None
     :param dict **query: Addition query parameters to be appended
     """
-    url = furl.furl(settings.WATERBUTLER_URL)
+    url = furl.furl(osf_settings.WATERBUTLER_URL)
     url.path.segments.append(waterbutler_action_map[route])
 
     url.args.update({
@@ -104,8 +126,8 @@ def waterbutler_url_for(route, provider, path, node, user=None, **query):
 
     if user:
         url.args['cookie'] = user.get_or_create_cookie()
-    elif settings.COOKIE_NAME in request.cookies:
-        url.args['cookie'] = request.cookies[settings.COOKIE_NAME]
+    elif osf_settings.COOKIE_NAME in request.cookies:
+        url.args['cookie'] = request.cookies[osf_settings.COOKIE_NAME]
 
     if 'view_only' in request.args:
         url.args['view_only'] = request.args['view_only']


### PR DESCRIPTION
Restores changes accidentally merged in #98 and reverted in #99, and adds JS unit tests. Also fixes bug whwere JS function could accidentally include doubled slashes.

For full description, see the original submission in centerforopenscience/osf.io/#2895