### PR TITLE
[ENG-2321] Do not allow non-contributors/read-onlys to see storage cap alerts

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1950,7 +1950,7 @@ var FGItemButtons = {
                 );
 
                 var storageLimitsStatus = window.contextVars.node.storageLimitsStatus;
-                if(storageLimitsStatus && storageLimitsStatus.disableUploads && window.contextVars.currentUser.isContributorOrGroupMember) {
+                if(storageLimitsStatus && storageLimitsStatus.disableUploads && window.contextVars.currentUser.can_edit) {
                     rowButtons.push(
                         m.component(FGButton, {
                             icon: 'fa fa-upload',
@@ -2222,7 +2222,7 @@ var FGToolbar = {
         }
 
         var storageLimitsStatus = window.contextVars.node.storageLimitsStatus;
-        if(storageLimitsStatus && window.contextVars.currentUser.isContributorOrGroupMember) {
+        if(storageLimitsStatus && window.contextVars.currentUser.can_edit) {
             generalButtons.push(
                 m.component(FGButton, {
                     icon: 'fa fa-exclamation-triangle',

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -873,8 +873,8 @@ function _fangornCanDrop(treebeard, item) {
     if (canDrop === null) {
         canDrop = item.data.provider && item.kind === 'folder' && item.data.permissions.edit;
     }
-    var status = window.contextVars.node.storageLimitsStatus;
-    if (status && status.disableUploads) {
+    var storageLimitsStatus = window.contextVars.node.storageLimitsStatus;
+    if (storageLimitsStatus && storageLimitsStatus.disableUploads) {
         return false;
     }
 
@@ -1948,12 +1948,14 @@ var FGItemButtons = {
                         className: 'text-success'
                     }, 'Create Folder')
                 );
-                if(window.contextVars.node.storageLimitsStatus && window.contextVars.node.storageLimitsStatus.disableUploads) {
+
+                var storageLimitsStatus = window.contextVars.node.storageLimitsStatus;
+                if(storageLimitsStatus && storageLimitsStatus.disableUploads && window.contextVars.currentUser.isContributorOrGroupMember) {
                     rowButtons.push(
                         m.component(FGButton, {
                             icon: 'fa fa-upload',
                             className : 'text-success disabled storage-disabled',
-                            tooltip: 'This project/component is ' + window.contextVars.node.storageLimitsStatus.text + ' the storage limit for OSF Storage. To learn more about limits and alternative storage options visit https://help.osf.io/.',
+                            tooltip: 'This project/component is ' + storageLimitsStatus.text + ' the storage limit for OSF Storage. To learn more about limits and alternative storage options visit https://help.osf.io/.',
                         }, 'Upload')
                     );
                 } else {
@@ -2218,12 +2220,14 @@ var FGToolbar = {
                 }, 'Cancel Pending Uploads')
             );
         }
-        if(window.contextVars.node.storageLimitsStatus) {
+
+        var storageLimitsStatus = window.contextVars.node.storageLimitsStatus;
+        if(storageLimitsStatus && window.contextVars.currentUser.isContributorOrGroupMember) {
             generalButtons.push(
                 m.component(FGButton, {
                     icon: 'fa fa-exclamation-triangle',
-                    className : window.contextVars.node.storageLimitsStatus.class,
-                    tooltip: 'This project/component is ' + window.contextVars.node.storageLimitsStatus.text + ' the storage limit for OSF Storage. To learn more about limits and alternative storage options click on this icon.',
+                    className : storageLimitsStatus.class,
+                    tooltip: 'This project/component is ' + storageLimitsStatus.text + ' the storage limit for OSF Storage. To learn more about limits and alternative storage options click on this icon.',
                     onclick: function() { window.open('https://help.osf.io/hc/en-us/articles/360054528874-OSF-Storage-Caps', '_blank'); }
                 })
             );

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -36,7 +36,7 @@
             <div class="col-lg-6">
                 <div class="btn-toolbar node-control pull-right">
                     <div class="btn-group">
-                        % if node.get('storage_limit_status') and node['storage_limit_status']['text']:
+                        % if node.get('storage_limit_status') and node['storage_limit_status']['text'] and permissions.WRITE in user['permissions']:
                             <a href="https://help.osf.io/hc/en-us/articles/360054528874-OSF-Storage-Caps"  target="_blank" class="btn ${node['storage_limit_status']['class']}"  data-toggle="tooltip" data-placement="bottom" title="This project/component is ${node['storage_limit_status']['text']} the storage limit for OSF Storage. To learn more about limits and alternative storage options click on this icon."><i class="fa fa-exclamation-triangle"></i></a>
                         % endif
 


### PR DESCRIPTION
## Purpose

Prevent non-contributors seeing storage cap warnings

## Changes

- adds checks for user permissions to display message

## QA Notes

- verify that only users with write and admins permissions can see storage warnings and their own node.

## Documentation

tech tasks, no docs

## Side Effects

None that I know of

## Ticket

https://openscience.atlassian.net/browse/ENG-2321